### PR TITLE
Fix build

### DIFF
--- a/samples/charts/data-chart/composite-chart/src/index.tsx
+++ b/samples/charts/data-chart/composite-chart/src/index.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import "./index.css";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './index.css';
 import {
   IgrDataChartCoreModule,
   IgrLegendModule,


### PR DESCRIPTION
fix build

There is a global gulp script bug where the following imports are getting stripped out when tsx files are copied over to the brower\samples folder

import ReactDOM from 'react-dom';
import './index.css';

The double quoted index.css was causing the build issue in this latest failure. so this temporarily fixes the build issue until the widespread fix is in place.