### PR TITLE
Rescope ig packages trial-> licensed explicitly in pipeline

### DIFF
--- a/azure-pipelines/build-pipeline.yml
+++ b/azure-pipelines/build-pipeline.yml
@@ -32,7 +32,7 @@ stages:
         displayName: 'Install Node'
         inputs:
           versionSource: 'spec'
-          versionSpec: '16.x'
+          versionSpec: '16.18.0'
 
       - task: RegexReplace@3
         enabled: false

--- a/azure-pipelines/build-pipeline.yml
+++ b/azure-pipelines/build-pipeline.yml
@@ -32,7 +32,7 @@ stages:
         displayName: 'Install Node'
         inputs:
           versionSource: 'spec'
-          versionSpec: '16.18.0'
+          versionSpec: '16.x'
 
       - task: RegexReplace@3
         enabled: false

--- a/azure-pipelines/build-pipeline.yml
+++ b/azure-pipelines/build-pipeline.yml
@@ -45,37 +45,74 @@ stages:
           UseRAW: true
 
       - task: Npm@1
+        displayName: 'Register licensed npm registry in .npmrc'
+        inputs:
+          command: 'custom'
+          workingDir: '$(Build.SourcesDirectory)\browser'
+          customCommand: 'config -L project set @infragistics:registry=https://packages.infragistics.com/npm/js-licensed/'
+          customEndpoint: 'internal proget'
+
+      - task: PowerShell@2
+        displayName: 'Replace references to IG trial packages with licensed ones'
+        inputs:
+          failOnStderr: true
+          showWarnings: true
+          workingDirectory: '$(Build.SourcesDirectory)\browser'
+          targetType: 'inline'
+          script: |
+            $packageJson = Get-Content -Raw .\package.json | ConvertFrom-Json
+            $properties = $packageJson.dependencies.PSObject.Properties `
+                | where-object { $_.Name.StartsWith("igniteui-react") -or $_.Name.StartsWith("igniteui-dockmanager") }
+
+            foreach( $property in $properties )
+            {
+                $oldName = $property.Name;
+                $newName = "@infragistics/" + $oldName
+
+                # remember the current value of the old property
+                $value = $property.Value;
+
+                # remove reference to the trial package reference
+                $packageJson.dependencies.psobject.Properties.Remove($oldName);
+
+                # add reference to the licensed package reference
+                $packageJson.dependencies | Add-Member -NotePropertyName $newName -NotePropertyValue $value;
+            }
+
+            ConvertTo-Json -InputObject $packageJson | Set-Content -Path .\package.json
+      - task: Npm@1
         displayName: 'npm install'
         inputs:
           command: custom
           workingDir: '$(Build.SourcesDirectory)\browser'
           verbose: ${{ parameters.isVerbose }}
           customCommand: 'install --legacy-peer-deps'
-
-      - task: Npm@1
-        displayName: 'npm uninstall igniteui-dockmanager (trial)'
-        inputs:
-          command: custom
-          workingDir: '$(Build.SourcesDirectory)\browser'
-          verbose: ${{ parameters.isVerbose }}
-          customCommand: 'uninstall igniteui-dockmanager --no-save'
-
-      - task: CmdLine@2
-        displayName: 'Install jq - using choco.'
-        inputs:
-          script: 'choco install jq -y'
-          failOnStderr: true
+          customEndpoint: 'public proget'
 
       - task: PowerShell@2
-        displayName: 'npm install igniteui-dockmanager (licensed)'
+        displayName: 'Replace references to IG trial packages with licensed ones in TSX files'
         inputs:
+          failOnStderr: true
+          showWarnings: true
+          workingDirectory: '$(Build.SourcesDirectory)'
           targetType: 'inline'
-          # We are using a PowerShell script because the npm step doesn't allow for explicit use of variable expansion which is what we use here.
-          # The script below grabs the current version of the dockmanager and installs it separately (after we UNinstalled it in a previous step)
           script: |
-            cd $(Build.SourcesDirectory)\browser
-            npm install igniteui-dockmanager@npm:@infragistics/igniteui-dockmanager@$($(jq '.dependencies.\"igniteui-dockmanager\"' .\package.json).Trim('"'))
+            Get-ChildItem -Include "*.tsx","*.ts" -Recurse | `
+            ForEach {  (Get-Content $_.PSPath | ForEach { ($_ -replace '([from|import])\s?[''"](igniteui-[react|dockmanager].*)[''"]', '$1 "@infragistics/$2"') }) | `
+            Set-Content $_.PSPath }
 
+      - task: PowerShell@2
+        displayName: 'Extra temporary replace for the dockmanager trial->licensed'
+        inputs:
+          failOnStderr: true
+          showWarnings: true
+          workingDirectory: '$(Build.SourcesDirectory)\browser\node_modules\@infragistics\igniteui-react'
+          targetType: 'inline'
+          script: |
+            Write-Output "$(Build.SourcesDirectory)\browser\node_modules\@infragistics\igniteui-react"
+            Get-ChildItem -Include "*.js" -Recurse | `
+            ForEach {  (Get-Content $_.PSPath | ForEach { ($_ -replace 'igniteui-dockmanager', '@infragistics/igniteui-dockmanager') }) | `
+            Set-Content $_.PSPath }
       - task: Npm@1
         displayName: 'npm run build'
         inputs:

--- a/browser/tslint.json
+++ b/browser/tslint.json
@@ -6,7 +6,7 @@
       "node_modules/**/*.ts",
       "coverage/lcov-report/*.js",
       "**/odatajs-4.0.0.js",
-      "src/samples/*.*",
+      "src/samples/**/*.*",
       "src/images/*.*",
       "src/navigation/*.tsx",
       "src/navigation/*.ts",


### PR DESCRIPTION
Given that we need to reference the scoped packages, we currently do so via explicit re-scoping of the IG packages + work around a temp bug in the igniteui-react package - how it references the docmanager