### PR TITLE
fix: grid pagingMode value and sync forceUpdate remove

### DIFF
--- a/samples/grids/grid/binding-composite-data/src/index.tsx
+++ b/samples/grids/grid/binding-composite-data/src/index.tsx
@@ -125,24 +125,21 @@ export default class Sample extends React.Component<any, any> {
         return (
             <>
                 <div className="contact-container--edit" style={{padding: "1rem"}}>
-                    <IgrInput label='Name' onInput={(e: any) =>
-                        {
-                            cell.row.data.ContactName = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.ContactName}></IgrInput>
-                    <IgrInput label='Title' onInput={(e: any) =>
-                        {
-                            cell.row.data.ContactTitle = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.ContactTitle}></IgrInput>
-                    <IgrInput label='Company' onInput={(e: any) =>
-                        {
-                            cell.row.data.Company = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.Company}></IgrInput>
+                    <IgrInput
+                        label='Name'
+                        onInput={(e: any) => cell.row.data.ContactName = e.detail}
+                        value={cell.row.data.ContactName}
+                    ></IgrInput>
+                    <IgrInput
+                        label='Title'
+                        onInput={(e: any) => cell.row.data.ContactTitle = e.detail}
+                        value={cell.row.data.ContactTitle}
+                    ></IgrInput>
+                    <IgrInput
+                        label='Company'
+                        onInput={(e: any) => cell.row.data.Company = e.detail}
+                        value={cell.row.data.Company}
+                    ></IgrInput>
                 </div>
             </>
         );
@@ -184,30 +181,26 @@ export default class Sample extends React.Component<any, any> {
         return (
             <>
                 <div className="contact-container--edit" style={{padding: "1rem"}}>
-                    <IgrInput label='Country' onInput={(e: any) =>
-                        {
-                            cell.row.data.Country = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.Country}></IgrInput>
-                    <IgrInput label='City' onInput={(e: any) =>
-                        {
-                            cell.row.data.City = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.City}></IgrInput>
-                    <IgrInput label='Postal Code' onInput={(e: any) =>
-                        {
-                            cell.row.data.PostalCode = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.PostalCode}></IgrInput>
-                    <IgrInput label='Phone' onInput={(e: any) =>
-                        {
-                            cell.row.data.Phone = e.detail;
-                            grid.forceUpdate();
-                        }
-                        } value={cell.row.data.Phone}></IgrInput>
+                    <IgrInput
+                        label='Country'
+                        onInput={(e: any) => cell.row.data.Country = e.detail}
+                        value={cell.row.data.Country}
+                    ></IgrInput>
+                    <IgrInput
+                        label='City'
+                        onInput={(e: any) => cell.row.data.City = e.detail}
+                        value={cell.row.data.City}
+                    ></IgrInput>
+                    <IgrInput
+                        label='Postal Code'
+                        onInput={(e: any) => cell.row.data.PostalCode = e.detail}
+                        value={cell.row.data.PostalCode}
+                    ></IgrInput>
+                    <IgrInput
+                        label='Phone'
+                        onInput={(e: any) => cell.row.data.Phone = e.detail}
+                        value={cell.row.data.Phone}
+                    ></IgrInput>
                 </div>
             </>
         );

--- a/samples/grids/grid/binding-crud-data/src/index.tsx
+++ b/samples/grids/grid/binding-crud-data/src/index.tsx
@@ -47,7 +47,7 @@ export default class Sample extends React.Component<any, any> {
                     primaryKey="ProductID"
                     isLoading={true}
                     allowFiltering={false}
-                    pagingMode="Remote"
+                    pagingMode="remote"
                     rowEditable={true}>
                     <IgrColumn
                         field="ProductName"

--- a/samples/grids/grid/multi-column-headers-template/src/index.tsx
+++ b/samples/grids/grid/multi-column-headers-template/src/index.tsx
@@ -173,7 +173,6 @@ export default class Sample extends React.Component<any, any> {
                 c.hidden = !c.hidden;
             }
         }
-        columnGroup.forceUpdate();
         this.columnGroupStates.set(columnGroup, !this.columnGroupStates.get(columnGroup));
     }
 }

--- a/samples/grids/grid/remote-paging-data/src/index.tsx
+++ b/samples/grids/grid/remote-paging-data/src/index.tsx
@@ -46,7 +46,7 @@ export default class Sample extends React.Component<any, any> {
                     data={this.nwindData}
                     moving={true}
                     allowAdvancedFiltering={true}
-                    pagingMode="Remote">
+                    pagingMode="remote">
                     <IgrPaginator
                         perPage={10}
                         totalRecords={20}>

--- a/samples/grids/hierarchical-grid/multi-column-headers-template/src/index.tsx
+++ b/samples/grids/hierarchical-grid/multi-column-headers-template/src/index.tsx
@@ -300,7 +300,6 @@ export default class Sample extends React.Component<any, any> {
                 c.hidden = !c.hidden;
             }
         }
-        columnGroup.forceUpdate();
         this.columnGroupStates.set(columnGroup, !this.columnGroupStates.get(columnGroup));
     }
 }

--- a/samples/grids/tree-grid/multi-column-headers-template/src/index.tsx
+++ b/samples/grids/tree-grid/multi-column-headers-template/src/index.tsx
@@ -175,7 +175,6 @@ export default class Sample extends React.Component<any, any> {
                 c.hidden = !c.hidden;
             }
         }
-        columnGroup.forceUpdate();
         this.columnGroupStates.set(columnGroup, !this.columnGroupStates.get(columnGroup));
     }
 }


### PR DESCRIPTION
- fix: [MANUAL] grid pagingMode value - Note that these are generated samples and I had a different fix with regular enum set, however those changed to string union and will not generate correctly before the metadata is updated
- chore: sync grid xplat samples remove of forceUpdate - from https://github.com/IgniteUI/igniteui-xplat-examples/pull/836