### PR TITLE
refactor(grids): updated samples to reflect docs changes

### DIFF
--- a/samples/grids/grid/remote-paging-grid/src/index.tsx
+++ b/samples/grids/grid/remote-paging-grid/src/index.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { IgrColumn, IgrGrid, IgrPaginator } from "igniteui-react-grids";
+import { IgrGrid, IgrPaginator } from "igniteui-react-grids";
+import { IgrColumn } from "igniteui-react-grids";
+import "igniteui-react-grids/grids/combined";
 import "igniteui-react-grids/grids/themes/light/bootstrap.css";
 import { RemoteService } from "./RemotePagingService";
 import { CustomersWithPageResponseModel } from "./CustomersWithPageResponseModel";

--- a/samples/grids/hierarchical-grid/remote-paging-hgrid/src/index.tsx
+++ b/samples/grids/hierarchical-grid/remote-paging-hgrid/src/index.tsx
@@ -77,13 +77,21 @@ export default function App() {
     setPerPage(args.detail);
   }
 
+  const onCustomersGridCreatedHandler = (e: IgrGridCreatedEventArgs) => {
+    gridCreated(e, "Customers")
+  };
+
+  const onOrdersGridCreatedHandler = (e: IgrGridCreatedEventArgs) => {
+    gridCreated(e, "Orders")
+  };
+
   return (
     <div className="container sample ig-typography">
       <div className="container fill">
         <IgrHierarchicalGrid
           ref={hierarchicalGrid}
           data={data}
-          pagingMode={"remote"}
+          pagingMode="remote"
           primaryKey="customerId"
           height="600px"
         >
@@ -103,9 +111,7 @@ export default function App() {
           <IgrRowIsland
             childDataKey="Orders"
             primaryKey="orderId"
-            onGridCreated={(e: IgrGridCreatedEventArgs) =>
-              gridCreated(e, "Customers")
-            }
+            onGridCreated={onCustomersGridCreatedHandler}
           >
             <IgrColumn field="orderId" hidden={true}></IgrColumn>
             <IgrColumn
@@ -126,9 +132,7 @@ export default function App() {
             <IgrRowIsland
               childDataKey="Details"
               primaryKey="productId"
-              onGridCreated={(e: IgrGridCreatedEventArgs) =>
-                gridCreated(e, "Orders")
-              }
+              onGridCreated={onOrdersGridCreatedHandler}
             >
               <IgrColumn field="productId" hidden={true}></IgrColumn>
               <IgrColumn field="quantity" header="Quantity"></IgrColumn>


### PR DESCRIPTION
Removed paging mode from the samples and updated Hgrd sample onGridCreated handlers to reflect changes in docs. The reason behind the change is because arrow functions assigned as event handlers were being detected as errors and the snippet was not being shown:

onEvent = { () => {} }

