### PR TITLE
Added extra class for hgrid images so they have the extra styling in grid cells only

### DIFF
--- a/browser/src/index.css
+++ b/browser/src/index.css
@@ -1,4 +1,4 @@
-img[src*="dl.infragistics.com/x/img/people"] {
+.igx-grid__td img[src*="dl.infragistics.com/x/img/people"] {
     width: 62px;
     height: 62px;
     object-fit: cover;


### PR DESCRIPTION
Samples like [dock pane's](https://www.infragistics.com/products/ignite-ui-react/react/components/layouts/dock-manager-updating-panes) are using the images and getting extra styling unintentionally