### PR TITLE
chore(samples): clean up deprecated imports and replace var with let/const

### DIFF
--- a/browser/templates/shared/src/DataGridSharedData.ts
+++ b/browser/templates/shared/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/charts/category-chart/annotations-all/src/index.tsx
+++ b/samples/charts/category-chart/annotations-all/src/index.tsx
@@ -126,7 +126,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            const context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/annotations-callouts/src/index.tsx
+++ b/samples/charts/category-chart/annotations-callouts/src/index.tsx
@@ -96,7 +96,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/annotations-crosshairs/src/index.tsx
+++ b/samples/charts/category-chart/annotations-crosshairs/src/index.tsx
@@ -108,7 +108,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/annotations-custom/src/index.tsx
+++ b/samples/charts/category-chart/annotations-custom/src/index.tsx
@@ -99,7 +99,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/annotations-final-value/src/index.tsx
+++ b/samples/charts/category-chart/annotations-final-value/src/index.tsx
@@ -98,7 +98,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/annotations-highlighting/src/index.tsx
+++ b/samples/charts/category-chart/annotations-highlighting/src/index.tsx
@@ -101,7 +101,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/axis-gap/src/index.tsx
+++ b/samples/charts/category-chart/axis-gap/src/index.tsx
@@ -110,7 +110,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/axis-gridlines/src/index.tsx
+++ b/samples/charts/category-chart/axis-gridlines/src/index.tsx
@@ -166,7 +166,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/axis-inverted/src/index.tsx
+++ b/samples/charts/category-chart/axis-inverted/src/index.tsx
@@ -104,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/axis-labels/src/index.tsx
+++ b/samples/charts/category-chart/axis-labels/src/index.tsx
@@ -141,7 +141,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/axis-locations/src/index.tsx
+++ b/samples/charts/category-chart/axis-locations/src/index.tsx
@@ -107,7 +107,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/axis-overlap/src/index.tsx
+++ b/samples/charts/category-chart/axis-overlap/src/index.tsx
@@ -109,7 +109,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/axis-range/src/index.tsx
+++ b/samples/charts/category-chart/axis-range/src/index.tsx
@@ -128,7 +128,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
@@ -138,13 +138,13 @@ export default class Sample extends React.Component<any, any> {
 
     public editorChangeUpdateYAxisMinimumValue(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
 
-    	var yAxisMinimumVal = args.newValue;
+    	let yAxisMinimumVal = args.newValue;
         this.chart.yAxisMinimumValue = parseInt(yAxisMinimumVal);
     }
 
     public editorChangeUpdateYAxisMaximumValue(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
 
-        var yAxisMaximumVal = args.newValue;
+        let yAxisMaximumVal = args.newValue;
         this.chart.yAxisMaximumValue = parseInt(yAxisMaximumVal);
     }
 

--- a/samples/charts/category-chart/axis-tickmarks/src/index.tsx
+++ b/samples/charts/category-chart/axis-tickmarks/src/index.tsx
@@ -114,7 +114,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/chart-highlight-filter/src/index.tsx
+++ b/samples/charts/category-chart/chart-highlight-filter/src/index.tsx
@@ -88,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/column-chart-with-tooltips/src/index.tsx
+++ b/samples/charts/category-chart/column-chart-with-tooltips/src/index.tsx
@@ -107,7 +107,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/custom-selection/src/index.tsx
+++ b/samples/charts/category-chart/custom-selection/src/index.tsx
@@ -84,9 +84,9 @@ export default class Sample extends React.Component<any, any> {
 
     public categoryChartCustomSelectionPointerDown(sender: any, args: IgrDomainChartSeriesPointerEventArgs): void {
 
-        var chart = this.chart;
-        var selectableData = chart.dataSource as SelectableData;
-    let oldItem = args.item as SelectableDataItem;
+        let chart = this.chart;
+        let selectableData = chart.dataSource as SelectableData;
+        let oldItem = args.item as SelectableDataItem;
 
         if (oldItem === null) return;
 
@@ -96,8 +96,8 @@ export default class Sample extends React.Component<any, any> {
             selectedValue: oldItem.selectedValue
         });
 
-        var selectedIndex = -1;
-        for (var i = 0; i < selectableData.length; i++) {
+        let selectedIndex = -1;
+        for (let i = 0; i < selectableData.length; i++) {
             if (oldItem.category === selectableData[i].category) {
                 selectedIndex = i;
                 break;

--- a/samples/charts/category-chart/data-aggregations/src/index.tsx
+++ b/samples/charts/category-chart/data-aggregations/src/index.tsx
@@ -104,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
@@ -114,9 +114,9 @@ export default class Sample extends React.Component<any, any> {
 
     public propertyEditorInitAggregationsOnViewInit(): void {
 
-        var editor = this.editor;
-        var initialSummariesDropdown = new IgrPropertyEditorPropertyDescription({});
-        var sortGroupsDropdown = new IgrPropertyEditorPropertyDescription({});
+        let editor = this.editor;
+        let initialSummariesDropdown = new IgrPropertyEditorPropertyDescription({});
+        let sortGroupsDropdown = new IgrPropertyEditorPropertyDescription({});
 
         initialSummariesDropdown.label = "Initial Summaries";
         initialSummariesDropdown.valueType = PropertyEditorValueType.EnumValue;
@@ -141,19 +141,19 @@ export default class Sample extends React.Component<any, any> {
 
     public editorChangeUpdateInitialSummaries(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
 
-        var chart = this.chart;
-        var intialSummaryVal = args.newValue.toString();
+        let chart = this.chart;
+        let intialSummaryVal = args.newValue.toString();
         chart.initialSummaries = intialSummaryVal;
     }
 
     public editorChangeUpdateGroupSorts(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var chart = this.chart;
-        var groupSortsVal = args.newValue.toString();
+        let chart = this.chart;
+        let groupSortsVal = args.newValue.toString();
         chart.groupSorts = groupSortsVal;
     }
 
     public editorChangeUpdateInitialGroups(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var chart = this.chart;
+        let chart = this.chart;
         chart.initialGroups = args.newValue.toString();
     }
 

--- a/samples/charts/category-chart/data-filter/src/index.tsx
+++ b/samples/charts/category-chart/data-filter/src/index.tsx
@@ -112,7 +112,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
@@ -122,8 +122,8 @@ export default class Sample extends React.Component<any, any> {
 
     public editorChangeDataFilter(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
 
-        var chart = this.chart;
-        var filter = args.newValue.toString();
+        let chart = this.chart;
+        let filter = args.newValue.toString();
         chart.initialFilter = "(contains(Year," + "'" + filter + "'" + "))";
     }
 

--- a/samples/charts/category-chart/data-tooltip-positioning/src/index.tsx
+++ b/samples/charts/category-chart/data-tooltip-positioning/src/index.tsx
@@ -110,7 +110,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/format-specifiers/src/index.tsx
+++ b/samples/charts/category-chart/format-specifiers/src/index.tsx
@@ -29,7 +29,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier1 == null)
         {
             let numberFormatSpecifier1: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier2 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier2 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier2.style = "currency";
             numberFormatSpecifier2.currency = "USD";
             numberFormatSpecifier2.currencyDisplay = "symbol";
@@ -51,7 +51,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier3 == null)
         {
             let numberFormatSpecifier3: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier4 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier4 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier4.style = "currency";
             numberFormatSpecifier4.currency = "USD";
             numberFormatSpecifier4.currencyDisplay = "symbol";
@@ -68,7 +68,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier5 == null)
         {
             let numberFormatSpecifier5: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier6 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier6 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier6.style = "currency";
             numberFormatSpecifier6.currency = "USD";
             numberFormatSpecifier6.currencyDisplay = "symbol";
@@ -135,7 +135,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataLegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/highlighting-behavior/src/index.tsx
+++ b/samples/charts/category-chart/highlighting-behavior/src/index.tsx
@@ -89,7 +89,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/highlighting-mode/src/index.tsx
+++ b/samples/charts/category-chart/highlighting-mode/src/index.tsx
@@ -88,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
         }

--- a/samples/charts/category-chart/marker-options/src/index.tsx
+++ b/samples/charts/category-chart/marker-options/src/index.tsx
@@ -104,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
             DataChartInteractivityDescriptionModule.register(context);
@@ -113,10 +113,10 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public editorChangeUpdateMarkerType(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var item = sender as IgrPropertyEditorPropertyDescription;
-        var chart = this.chart;
+        let item = sender as IgrPropertyEditorPropertyDescription;
+        let chart = this.chart;
 
-        var markerVal = item.primitiveValue;
+        let markerVal = item.primitiveValue;
         chart.markerTypes = markerVal;
     }
 

--- a/samples/charts/category-chart/selection-matcher/src/index.tsx
+++ b/samples/charts/category-chart/selection-matcher/src/index.tsx
@@ -86,7 +86,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
             DataChartAnnotationDescriptionModule.register(context);
@@ -100,23 +100,23 @@ export default class Sample extends React.Component<any, any> {
 
     public selectionMatcherOnViewInit(): void {
 
-    	var chart = this.chart;
+    	let chart = this.chart;
 
     	this._timer = setInterval(() => {
-    	var data = this.energyRenewableConsumption;
+    	let data = this.energyRenewableConsumption;
 
-        var matcher = new IgrSeriesMatcher();
+        let matcher = new IgrSeriesMatcher();
 
-        var selection = new IgrChartSelection();
+        let selection = new IgrChartSelection();
     		selection.item = data[1];
     		matcher.memberPath = "hydro";
     		matcher.memberPathType = "ValueMemberPath";
     		selection.matcher = matcher;
     		chart.selectedSeriesItems.add(selection);
 
-    	var matcher2 = new IgrSeriesMatcher();
+    	let matcher2 = new IgrSeriesMatcher();
 
-    var selection2 = new IgrChartSelection();
+    let selection2 = new IgrChartSelection();
     		selection2.item = data[2];
     		matcher2.memberPath = "wind";
     		matcher2.memberPathType = "ValueMemberPath";

--- a/samples/charts/category-chart/selection-multiple-modes/src/index.tsx
+++ b/samples/charts/category-chart/selection-multiple-modes/src/index.tsx
@@ -117,7 +117,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);

--- a/samples/charts/category-chart/value-lines/src/index.tsx
+++ b/samples/charts/category-chart/value-lines/src/index.tsx
@@ -116,7 +116,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             LegendDescriptionModule.register(context);
             CategoryChartDescriptionModule.register(context);
@@ -125,10 +125,10 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public editorChangeUpdateValueLines(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var item = sender as IgrPropertyEditorPropertyDescription;
-        var chart = this.chart;
+        let item = sender as IgrPropertyEditorPropertyDescription;
+        let chart = this.chart;
 
-        var valueLineType = item.primitiveValue;
+        let valueLineType = item.primitiveValue;
         chart.valueLines = valueLineType;
     }
 

--- a/samples/charts/dashboard-tile/local-data-source-dashboard/src/RetailSalesPerformanceLocalDataSource.ts
+++ b/samples/charts/dashboard-tile/local-data-source-dashboard/src/RetailSalesPerformanceLocalDataSource.ts
@@ -7,7 +7,7 @@ export class RetailSalesPerformanceLocalDataSource extends LocalDataSource {
   public constructor() {
     super();
 
-    var data = [
+    let data = [
       {
         "Category": "Home Appliances",
         "Subcategory": "Cleaning",

--- a/samples/charts/data-chart/axis-label-rotation/src/index.tsx
+++ b/samples/charts/data-chart/axis-label-rotation/src/index.tsx
@@ -117,7 +117,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);
             DataChartInteractivityDescriptionModule.register(context);

--- a/samples/charts/data-chart/chart-highlight-filter-datasource/src/index.tsx
+++ b/samples/charts/data-chart/chart-highlight-filter-datasource/src/index.tsx
@@ -115,7 +115,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);

--- a/samples/charts/data-chart/chart-highlight-filter-multiple-series/src/index.tsx
+++ b/samples/charts/data-chart/chart-highlight-filter-multiple-series/src/index.tsx
@@ -131,7 +131,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);

--- a/samples/charts/data-chart/chart-highlight-filter/src/index.tsx
+++ b/samples/charts/data-chart/chart-highlight-filter/src/index.tsx
@@ -105,7 +105,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);

--- a/samples/charts/data-chart/composite-chart/src/index.tsx
+++ b/samples/charts/data-chart/composite-chart/src/index.tsx
@@ -106,7 +106,7 @@ export default class DataChartCompositeChart extends React.Component<any, any> {
   }
 
   public formatNumber(num: number): string {
-    var ret = num;
+    let ret = num;
     if (num >= 1000000) return (num / 1000000.0).toFixed(1) + "M";
     if (num >= 1000) return (num / 1000.0).toFixed(1) + "K";
 

--- a/samples/charts/data-chart/data-legend-grouping-and-highlighting/src/index.tsx
+++ b/samples/charts/data-chart/data-legend-grouping-and-highlighting/src/index.tsx
@@ -123,7 +123,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             LegendDescriptionModule.register(context);
             NumberAbbreviatorDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);

--- a/samples/charts/data-chart/data-legend-grouping/src/index.tsx
+++ b/samples/charts/data-chart/data-legend-grouping/src/index.tsx
@@ -111,7 +111,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             LegendDescriptionModule.register(context);
             NumberAbbreviatorDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);

--- a/samples/charts/data-chart/data-legend-styling/src/index.tsx
+++ b/samples/charts/data-chart/data-legend-styling/src/index.tsx
@@ -105,7 +105,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             LegendDescriptionModule.register(context);
             NumberAbbreviatorDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);

--- a/samples/charts/data-chart/data-legend/src/index.tsx
+++ b/samples/charts/data-chart/data-legend/src/index.tsx
@@ -37,7 +37,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale1(): IgrSizeScale {
         if (this._sizeScale1 == null)
         {
-            var SizeScale1 = new IgrSizeScale({});
+            let SizeScale1 = new IgrSizeScale({});
 
             SizeScale1.minimumValue = 10;
             SizeScale1.maximumValue = 50;
@@ -51,7 +51,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale2(): IgrSizeScale {
         if (this._sizeScale2 == null)
         {
-            var SizeScale2 = new IgrSizeScale({});
+            let SizeScale2 = new IgrSizeScale({});
 
             SizeScale2.minimumValue = 10;
             SizeScale2.maximumValue = 50;

--- a/samples/charts/data-chart/data-tooltip-grouping-and-highlighting/src/index.tsx
+++ b/samples/charts/data-chart/data-tooltip-grouping-and-highlighting/src/index.tsx
@@ -114,7 +114,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);

--- a/samples/charts/data-chart/data-tooltip-grouping/src/index.tsx
+++ b/samples/charts/data-chart/data-tooltip-grouping/src/index.tsx
@@ -104,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);

--- a/samples/charts/data-chart/data-tooltip-styling/src/index.tsx
+++ b/samples/charts/data-chart/data-tooltip-styling/src/index.tsx
@@ -90,7 +90,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);

--- a/samples/charts/data-chart/data-tooltip/src/index.tsx
+++ b/samples/charts/data-chart/data-tooltip/src/index.tsx
@@ -31,7 +31,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale1(): IgrSizeScale {
         if (this._sizeScale1 == null)
         {
-            var SizeScale1 = new IgrSizeScale({});
+            let SizeScale1 = new IgrSizeScale({});
 
             SizeScale1.minimumValue = 10;
             SizeScale1.maximumValue = 50;
@@ -45,7 +45,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale2(): IgrSizeScale {
         if (this._sizeScale2 == null)
         {
-            var SizeScale2 = new IgrSizeScale({});
+            let SizeScale2 = new IgrSizeScale({});
 
             SizeScale2.minimumValue = 10;
             SizeScale2.maximumValue = 50;

--- a/samples/charts/data-chart/format-specifiers/src/index.tsx
+++ b/samples/charts/data-chart/format-specifiers/src/index.tsx
@@ -29,7 +29,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier1 == null)
         {
             let numberFormatSpecifier1: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier2 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier2 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier2.style = "currency";
             numberFormatSpecifier2.currency = "USD";
             numberFormatSpecifier2.currencyDisplay = "symbol";
@@ -53,7 +53,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier3 == null)
         {
             let numberFormatSpecifier3: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier4 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier4 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier4.style = "currency";
             numberFormatSpecifier4.currency = "USD";
             numberFormatSpecifier4.currencyDisplay = "symbol";
@@ -72,7 +72,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier5 == null)
         {
             let numberFormatSpecifier5: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier6 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier6 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier6.style = "currency";
             numberFormatSpecifier6.currency = "USD";
             numberFormatSpecifier6.currencyDisplay = "symbol";

--- a/samples/charts/data-chart/radial-label-mode/src/index.tsx
+++ b/samples/charts/data-chart/radial-label-mode/src/index.tsx
@@ -162,7 +162,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartRadialDescriptionModule.register(context);

--- a/samples/charts/data-chart/scatter-bubble-chart-fill-scale/src/index.tsx
+++ b/samples/charts/data-chart/scatter-bubble-chart-fill-scale/src/index.tsx
@@ -30,7 +30,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale1(): IgrSizeScale {
         if (this._sizeScale1 == null)
         {
-            var sizeScale1 = new IgrSizeScale({});
+            let sizeScale1 = new IgrSizeScale({});
             sizeScale1.isLogarithmic = false;
             sizeScale1.minimumValue = 10;
             sizeScale1.maximumValue = 80;
@@ -43,7 +43,7 @@ export default class Sample extends React.Component<any, any> {
     public get valueBrushScale1(): IgrValueBrushScale {
         if (this._valueBrushScale1 == null)
         {
-            var valueBrushScale1 = new IgrValueBrushScale({});
+            let valueBrushScale1 = new IgrValueBrushScale({});
             valueBrushScale1.isLogarithmic = false;
             valueBrushScale1.minimumValue = 500;
             valueBrushScale1.maximumValue = 260000;
@@ -147,7 +147,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             NumberAbbreviatorDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartScatterDescriptionModule.register(context);

--- a/samples/charts/data-chart/scatter-bubble-chart-multiple-sources/src/index.tsx
+++ b/samples/charts/data-chart/scatter-bubble-chart-multiple-sources/src/index.tsx
@@ -35,7 +35,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale1(): IgrSizeScale {
         if (this._sizeScale1 == null)
         {
-            var sizeScale1 = new IgrSizeScale({});
+            let sizeScale1 = new IgrSizeScale({});
             sizeScale1.isLogarithmic = false;
             sizeScale1.minimumValue = 10;
             sizeScale1.maximumValue = 80;
@@ -49,7 +49,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale2(): IgrSizeScale {
         if (this._sizeScale2 == null)
         {
-            var sizeScale2 = new IgrSizeScale({});
+            let sizeScale2 = new IgrSizeScale({});
             sizeScale2.isLogarithmic = false;
             sizeScale2.minimumValue = 10;
             sizeScale2.maximumValue = 80;

--- a/samples/charts/data-chart/scatter-bubble-chart-single-source/src/index.tsx
+++ b/samples/charts/data-chart/scatter-bubble-chart-single-source/src/index.tsx
@@ -29,7 +29,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale1(): IgrSizeScale {
         if (this._sizeScale1 == null)
         {
-            var sizeScale1 = new IgrSizeScale({});
+            let sizeScale1 = new IgrSizeScale({});
             sizeScale1.isLogarithmic = false;
             sizeScale1.minimumValue = 10;
             sizeScale1.maximumValue = 80;

--- a/samples/charts/data-chart/scatter-bubble-chart-styling/src/index.tsx
+++ b/samples/charts/data-chart/scatter-bubble-chart-styling/src/index.tsx
@@ -30,7 +30,7 @@ export default class Sample extends React.Component<any, any> {
     public get sizeScale1(): IgrSizeScale {
         if (this._sizeScale1 == null)
         {
-            var sizeScale1 = new IgrSizeScale({});
+            let sizeScale1 = new IgrSizeScale({});
             sizeScale1.isLogarithmic = false;
             sizeScale1.minimumValue = 10;
             sizeScale1.maximumValue = 80;

--- a/samples/charts/data-chart/scatter-line-threshold/src/index.tsx
+++ b/samples/charts/data-chart/scatter-line-threshold/src/index.tsx
@@ -120,7 +120,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public getActualData() : any[] {
-        var data: any[] = [];
+        let data: any[] = [];
         data.push( { x: 0, y: 50 } );
         data.push( { x: 1, y: 20 } );
         data.push( { x: 2, y: 40 } );
@@ -146,9 +146,9 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public getThresholdData(thresholdValue : number) : any[] {
-        var data: any[] = [];
+        let data: any[] = [];
         for (let i = 0; i < this.actualDataSource.length; i++) {
-            var curr = this.actualDataSource[i];
+            let curr = this.actualDataSource[i];
 
             if (curr.y >= thresholdValue) {
                 data.push( curr );
@@ -157,12 +157,12 @@ export default class Sample extends React.Component<any, any> {
             }
             // calculating threshold line segments that are above the threshold value
             if (i < this.actualDataSource.length - 1) {
-                var next = this.actualDataSource[i+1];
+                let next = this.actualDataSource[i+1];
                 if ((curr.y <  thresholdValue && next.y > thresholdValue) ||
                     (curr.y >= thresholdValue && next.y < thresholdValue)) {
-                    var m = (curr.y - next.y) / (curr.x - next.x);
-                    var b = curr.y - (curr.x * m);
-                    var x = (thresholdValue - b) / m;
+                    let m = (curr.y - next.y) / (curr.x - next.x);
+                    let b = curr.y - (curr.x * m);
+                    let x = (thresholdValue - b) / m;
                     data.push( { x: x, y: thresholdValue } );
                 }
             }
@@ -171,7 +171,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public onThresholdValueChange(e: any) {
-        var value = e.target.value
+        let value = e.target.value
         this.setState({
             thresholdValue: value,
             thresholdData: this.getThresholdData(value)

--- a/samples/charts/data-chart/selection-matcher/src/index.tsx
+++ b/samples/charts/data-chart/selection-matcher/src/index.tsx
@@ -135,23 +135,23 @@ export default class Sample extends React.Component<any, any> {
 
     public selectionMatcherOnViewInit(): void {
 
-    	var chart = this.chart;
+    	let chart = this.chart;
 
     	this._timer = setInterval(() => {
-    	var data = this.energyRenewableConsumption;
+    	let data = this.energyRenewableConsumption;
 
-        var matcher = new IgrSeriesMatcher();
+        let matcher = new IgrSeriesMatcher();
 
-        var selection = new IgrChartSelection();
+        let selection = new IgrChartSelection();
     		selection.item = data[1];
     		matcher.memberPath = "hydro";
     		matcher.memberPathType = "ValueMemberPath";
     		selection.matcher = matcher;
     		chart.selectedSeriesItems.add(selection);
 
-    	var matcher2 = new IgrSeriesMatcher();
+    	let matcher2 = new IgrSeriesMatcher();
 
-    var selection2 = new IgrChartSelection();
+    let selection2 = new IgrChartSelection();
     		selection2.item = data[2];
     		matcher2.memberPath = "wind";
     		matcher2.memberPathType = "ValueMemberPath";

--- a/samples/charts/data-chart/transition-event/src/index.tsx
+++ b/samples/charts/data-chart/transition-event/src/index.tsx
@@ -129,7 +129,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataChartCoreDescriptionModule.register(context);
             DataChartCategoryDescriptionModule.register(context);
@@ -138,8 +138,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public editorButtonReplayTransitionIn(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
-        var series = this.chart.actualSeries;
-        for (var i = 0; i < series.length; i++) {
+        let series = this.chart.actualSeries;
+        for (let i = 0; i < series.length; i++) {
             series[i].replayTransitionIn();
         }
     }

--- a/samples/charts/data-chart/trendline-layer/src/index.tsx
+++ b/samples/charts/data-chart/trendline-layer/src/index.tsx
@@ -118,7 +118,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             DataChartCategoryDescriptionModule.register(context);
             DataChartInteractivityDescriptionModule.register(context);
             DataChartAnnotationDescriptionModule.register(context);

--- a/samples/charts/data-chart/user-annotation-layer/src/index.tsx
+++ b/samples/charts/data-chart/user-annotation-layer/src/index.tsx
@@ -55,12 +55,12 @@ export default class Sample extends React.Component<any, any> {
     private mainColorPickerRef(r: IgrColorEditor) {
         this.mainColorPicker = r;
         this.setState({});
-    }   
+    }
 
     private currentAnnotationInfo: IgrUserAnnotationInformation;
 
     constructor(props: any) {
-        super(props);        
+        super(props);
         this.chartRef = this.chartRef.bind(this);
         this.onDoneButtonClick = this.onDoneButtonClick.bind(this);
         this.onCancelButtonClick = this.onCancelButtonClick.bind(this);
@@ -160,24 +160,24 @@ export default class Sample extends React.Component<any, any> {
 
     public onUserAnnotationInformationRequested(s: IgrSeriesViewer<IIgrSeriesViewerProps>, e: IgrUserAnnotationInformationEventArgs){
         this.currentAnnotationInfo = e.annotationInfo;
-        this.toggleDialogState(true);    
+        this.toggleDialogState(true);
     }
 
     public onUserAnnotationToolTipContentUpdating(s: IgrSeriesViewer<IIgrSeriesViewerProps>, e: IgrUserAnnotationToolTipContentUpdatingEventArgs){
-        var tooltipText = e.annotationInfo.annotationData;
+        let tooltipText = e.annotationInfo.annotationData;
 
         if (e.content.children.length == 0) {
-            var element = document.createElement("div");
+            let element = document.createElement("div");
             element.textContent = tooltipText;
             e.content.appendChild(element);
         }
         else {
-            var element: HTMLDivElement = e.content.children[0];
+            let element: HTMLDivElement = e.content.children[0];
             element.textContent = tooltipText;
         }
     }
 
-    public onDoneButtonClick(){    
+    public onDoneButtonClick(){
         this.currentAnnotationInfo.label = this.labelInput.value;
         this.currentAnnotationInfo.annotationData = this.detailTextArea.value;
         this.currentAnnotationInfo.mainColor = this.mainColorPicker.value;
@@ -194,7 +194,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleDialogState(open: boolean): void {
-        var popup = document.getElementsByClassName('annotationPopup')[0] as HTMLDivElement;
+        let popup = document.getElementsByClassName('annotationPopup')[0] as HTMLDivElement;
 
         if (open) {
             popup.style.display = "block";

--- a/samples/charts/data-pie-chart/animation-replay/src/index.tsx
+++ b/samples/charts/data-pie-chart/animation-replay/src/index.tsx
@@ -93,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataPieChartDescriptionModule.register(context);
             ItemLegendDescriptionModule.register(context);
@@ -102,7 +102,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public editorButtonReplayTransitionInDomain(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
-        var chart = this.chart;
+        let chart = this.chart;
         chart.replayTransitionIn();
     }
 

--- a/samples/charts/data-pie-chart/animation/src/index.tsx
+++ b/samples/charts/data-pie-chart/animation/src/index.tsx
@@ -95,7 +95,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataPieChartDescriptionModule.register(context);
             ItemLegendDescriptionModule.register(context);

--- a/samples/charts/data-pie-chart/highlight-filter/src/index.tsx
+++ b/samples/charts/data-pie-chart/highlight-filter/src/index.tsx
@@ -64,7 +64,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             DataPieChartDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/charts/data-pie-chart/highlighting/src/index.tsx
+++ b/samples/charts/data-pie-chart/highlighting/src/index.tsx
@@ -94,7 +94,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataPieChartDescriptionModule.register(context);
             ItemLegendDescriptionModule.register(context);

--- a/samples/charts/data-pie-chart/legend/src/index.tsx
+++ b/samples/charts/data-pie-chart/legend/src/index.tsx
@@ -73,7 +73,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataPieChartDescriptionModule.register(context);
             ItemLegendDescriptionModule.register(context);

--- a/samples/charts/data-pie-chart/others/src/index.tsx
+++ b/samples/charts/data-pie-chart/others/src/index.tsx
@@ -105,7 +105,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataPieChartDescriptionModule.register(context);
             ItemLegendDescriptionModule.register(context);

--- a/samples/charts/data-pie-chart/selection/src/index.tsx
+++ b/samples/charts/data-pie-chart/selection/src/index.tsx
@@ -102,7 +102,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             DataPieChartDescriptionModule.register(context);
             ItemLegendDescriptionModule.register(context);

--- a/samples/charts/financial-chart/format-specifiers/src/index.tsx
+++ b/samples/charts/financial-chart/format-specifiers/src/index.tsx
@@ -28,7 +28,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier1 == null)
         {
             let numberFormatSpecifier1: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier2 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier2 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier2.currency = "EUR";
             numberFormatSpecifier2.style = "currency";
             numberFormatSpecifier2.locale = "en-GB";
@@ -50,7 +50,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier3 == null)
         {
             let numberFormatSpecifier3: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier4 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier4 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier4.currency = "EUR";
             numberFormatSpecifier4.style = "currency";
             numberFormatSpecifier4.locale = "en-GB";
@@ -67,7 +67,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._numberFormatSpecifier5 == null)
         {
             let numberFormatSpecifier5: IgrNumberFormatSpecifier[] = [];
-            var numberFormatSpecifier6 = new IgrNumberFormatSpecifier();
+            let numberFormatSpecifier6 = new IgrNumberFormatSpecifier();
             numberFormatSpecifier6.currency = "EUR";
             numberFormatSpecifier6.style = "currency";
             numberFormatSpecifier6.locale = "en-GB";
@@ -83,7 +83,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._dateTimeFormatSpecifier1 == null)
         {
             let dateTimeFormatSpecifier1: IgrDateTimeFormatSpecifier[] = [];
-            var dateTimeFormatSpecifier2 = new IgrDateTimeFormatSpecifier();
+            let dateTimeFormatSpecifier2 = new IgrDateTimeFormatSpecifier();
             dateTimeFormatSpecifier2.locale = "en-GB";
             dateTimeFormatSpecifier2.dateStyle = "long";
 

--- a/samples/charts/sparkline/display-lines/src/index.tsx
+++ b/samples/charts/sparkline/display-lines/src/index.tsx
@@ -57,7 +57,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             SparklineDescriptionModule.register(context);
         }

--- a/samples/charts/sparkline/markers/src/index.tsx
+++ b/samples/charts/sparkline/markers/src/index.tsx
@@ -151,7 +151,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             SparklineDescriptionModule.register(context);
         }

--- a/samples/charts/sparkline/normal-range/src/index.tsx
+++ b/samples/charts/sparkline/normal-range/src/index.tsx
@@ -112,7 +112,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             SparklineDescriptionModule.register(context);
         }

--- a/samples/charts/sparkline/trendlines/src/index.tsx
+++ b/samples/charts/sparkline/trendlines/src/index.tsx
@@ -88,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             SparklineDescriptionModule.register(context);
         }

--- a/samples/charts/sparkline/unknown-values/src/index.tsx
+++ b/samples/charts/sparkline/unknown-values/src/index.tsx
@@ -88,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             SparklineDescriptionModule.register(context);
         }

--- a/samples/charts/toolbar/color-editor-support/src/index.tsx
+++ b/samples/charts/toolbar/color-editor-support/src/index.tsx
@@ -111,18 +111,18 @@ export default class Sample extends React.Component<any, any> {
 
 
     public colorEditorToggleSeriesBrush(sender: any, args: IgrToolCommandEventArgs): void {
-        var target = this.chart;
+        let target = this.chart;
 
-    	switch (args.command.commandId)
-    	{
-            case "ToggleSeriesBrush":
-                var color = args.command.argumentsList[0].value
-                var series = target.contentSeries[0] as IgrSeries;
-                series.brush = color as any;
-            break;
+       	switch (args.command.commandId)
+       	{
+                case "ToggleSeriesBrush":{
+                    const color = args.command.argumentsList[0].value;
+                    const series = target.contentSeries[0] as IgrSeries;
+                    series.brush = color as any;
+                    break;
+                }
         }
     }
-
 }
 
 // rendering above component in the React DOM

--- a/samples/charts/toolbar/layout-actions-for-data-chart/src/index.tsx
+++ b/samples/charts/toolbar/layout-actions-for-data-chart/src/index.tsx
@@ -183,19 +183,19 @@ export default class Sample extends React.Component<any, any> {
 
 
     public toolbarToggleAnnotations(sender: any, args: IgrToolCommandEventArgs): void {
-        var target = this.chart;
+        let target = this.chart;
         switch (args.command.commandId)
     	{
-    		case "EnableTooltips":
-    			var enable = args.command.argumentsList[0].value as boolean;
+    		case "EnableTooltips": {
+    			const enable = args.command.argumentsList[0].value as boolean;
     			if (enable)
     			{
     				target.series.add(new IgrDataToolTipLayer({ name: "tooltipLayer" }));
     			}
     			else
     			{
-    				var toRemove = null;
-    				for (var i = 0; i < target.actualSeries.length; i++) {
+    				let toRemove = null;
+    				for (let i = 0; i < target.actualSeries.length; i++) {
                         let s = target.actualSeries[i] as IgrSeries;
     					if (s instanceof IgrDataToolTipLayer)
     					{
@@ -207,17 +207,18 @@ export default class Sample extends React.Component<any, any> {
     					target.series.remove(toRemove);
     				}
     			}
-    			break;
-    		case "EnableCrosshairs":
-    			var enable = args.command.argumentsList[0].value as boolean;
+            break;
+      }
+    		case "EnableCrosshairs":{
+    			const enable = args.command.argumentsList[0].value as boolean;
     			if (enable)
     			{
     				target.series.add(new IgrCrosshairLayer({ name: "crosshairLayer" }));
     			}
     			else
     			{
-    				var toRemove = null;
-    				for (var i = 0; i < target.actualSeries.length; i++) {
+    				let toRemove = null;
+    				for (let i = 0; i < target.actualSeries.length; i++) {
     					let s = target.actualSeries[i] as IgrSeries;
     					if (s instanceof IgrCrosshairLayer)
     					{
@@ -229,17 +230,18 @@ export default class Sample extends React.Component<any, any> {
     					target.series.remove(toRemove);
     				}
     			}
-    			break;
-    		case "EnableFinalValues":
-    			var enable = args.command.argumentsList[0].value as boolean;
+            break;
+      }
+    		case "EnableFinalValues":{
+    			const enable = args.command.argumentsList[0].value as boolean;
     			if (enable)
     			{
     				target.series.add(new IgrFinalValueLayer({ name: "finalValueLayer" }));
     			}
     			else
     			{
-    				var toRemove = null;
-    				for (var i = 0; i < target.actualSeries.length; i++) {
+    				let toRemove = null;
+    				for (let i = 0; i < target.actualSeries.length; i++) {
     					let s = target.actualSeries[i] as IgrSeries;
     					if (s instanceof IgrFinalValueLayer)
     					{
@@ -251,7 +253,8 @@ export default class Sample extends React.Component<any, any> {
     					target.series.remove(toRemove);
     				}
     			}
-    			break;
+            break;
+      }
     	}
     }
 

--- a/samples/charts/toolbar/theming/src/index.tsx
+++ b/samples/charts/toolbar/theming/src/index.tsx
@@ -127,7 +127,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             ToolbarDescriptionModule.register(context);
             DataChartToolbarDescriptionModule.register(context);

--- a/samples/charts/tree-map/highlighting-percent-based/src/index.tsx
+++ b/samples/charts/tree-map/highlighting-percent-based/src/index.tsx
@@ -71,7 +71,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             TreemapDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/charts/tree-map/highlighting/src/index.tsx
+++ b/samples/charts/tree-map/highlighting/src/index.tsx
@@ -102,7 +102,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             TreemapDescriptionModule.register(context);
         }

--- a/samples/charts/tree-map/layout/src/index.tsx
+++ b/samples/charts/tree-map/layout/src/index.tsx
@@ -117,7 +117,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             TreemapDescriptionModule.register(context);
         }

--- a/samples/grids/data-grid/cell-activation/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/cell-activation/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/cell-editing/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/cell-editing/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/cell-editing/src/index.tsx
+++ b/samples/grids/data-grid/cell-editing/src/index.tsx
@@ -151,7 +151,7 @@ export default class DataGridCellEditing extends React.Component<any, any> {
 
     //#region Grid Handlers
     onDeleteRowClick = (e: MouseEvent) => {
-        const button = e.srcElement as HTMLButtonElement;
+        const button = e.target as HTMLButtonElement;
         const viewIndex = parseInt(button.id);
         const rowItem = this.grid.actualDataSource.getItemAtIndex(viewIndex);
 

--- a/samples/grids/data-grid/cell-selection/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/cell-selection/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-animation/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-animation/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-chooser-picker/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-chooser-picker/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-chooser-toolbar/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-chooser-toolbar/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-filter-expressions/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-filter-expressions/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-filter-operands/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-filter-operands/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-filtering/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-filtering/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-moving/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-moving/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-options/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-options/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-pinning-picker/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-pinning-picker/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-pinning-toolbar/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-pinning-toolbar/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-resizing/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-resizing/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-scrolling/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-scrolling/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-sorting/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-sorting/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-summaries/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-summaries/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/column-types/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/column-types/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/load-save-layout/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/load-save-layout/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/localization/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/localization/src/DataGridSharedData.ts
@@ -145,7 +145,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/overview/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/overview/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/row-group-descriptions/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/row-group-descriptions/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/row-grouping/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/row-grouping/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/row-highlighting/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/row-highlighting/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/row-paging/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/row-paging/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/row-pinning/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/row-pinning/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/data-grid/row-selection/src/DataGridSharedData.ts
+++ b/samples/grids/data-grid/row-selection/src/DataGridSharedData.ts
@@ -144,7 +144,7 @@ export class DataGridSharedData {
             const gender: string = this.getRandomGender();
             const firstName: string = this.getRandomNameFirst(gender);
             const lastName: string = this.getRandomNameLast();
-            const initials = firstName.substr(0, 1).toLowerCase();
+            const initials = firstName.substring(0, 1).toLowerCase();
             const email: string = initials + lastName.toLowerCase() + "@" + this.getRandomItem(emails);
 
             const street: string = this.getRandomStreet();

--- a/samples/grids/grid/action-strip/src/index.tsx
+++ b/samples/grids/grid/action-strip/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPinningConfig, RowPinningPosition, IgrActionStrip, IgrGridPinningActions, IgrGridEditingActions, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -11,8 +10,7 @@ import NwindData from './NwindData.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -26,7 +24,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -108,7 +106,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/advanced-filtering-options/src/index.tsx
+++ b/samples/grids/grid/advanced-filtering-options/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -10,10 +9,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -98,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/advanced-filtering-style/src/index.tsx
+++ b/samples/grids/grid/advanced-filtering-style/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -10,10 +9,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -93,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/binding-composite-data/src/index.tsx
+++ b/samples/grids/grid/binding-composite-data/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrInputModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
@@ -12,7 +11,6 @@ import { IgrInput } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrInputModule
 ];
 mods.forEach((m) => m.register());
@@ -95,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
 
 
     public webGridCompositeContactCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         if (cell === undefined || cell.row === undefined || cell.row.data === undefined) {
             return <></>;
         }
@@ -116,8 +114,8 @@ export default class Sample extends React.Component<any, any> {
 
     public webGridCompositeContactEditCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
 
-        var cell = props.dataContext.cell as any;
-        var grid = this.grid;
+        let cell = props.dataContext.cell as any;
+        let grid = this.grid;
         if (cell === undefined || cell.row === undefined || cell.row.data === undefined) {
             return <></>
         }
@@ -146,7 +144,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridCompositeAddressCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         if (cell === undefined || cell.row === undefined || cell.row.data === undefined) {
             return <></>;
         }
@@ -172,8 +170,8 @@ export default class Sample extends React.Component<any, any> {
 
     public webGridCompositeAddressEditCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
 
-        var cell = props.dataContext.cell as any;
-        var grid = this.grid;
+        let cell = props.dataContext.cell as any;
+        let grid = this.grid;
         if (cell === undefined || cell.row === undefined || cell.row.data === undefined) {
             return <></>;
         }

--- a/samples/grids/grid/binding-crud-data/src/index.tsx
+++ b/samples/grids/grid/binding-crud-data/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -11,8 +10,7 @@ import NwindData from './NwindData.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -79,7 +77,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/binding-nested-data-1/src/index.tsx
+++ b/samples/grids/grid/binding-nested-data-1/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrInputModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesNestedDataItem, EmployeesNestedDataItem_EmployeesItem, EmployeesNestedData } from './EmployeesNestedData';
@@ -12,7 +11,6 @@ import { IgrExpansionPanel, IgrInput } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrInputModule
 ];
 mods.forEach((m) => m.register());
@@ -102,7 +100,7 @@ export default class Sample extends React.Component<any, any> {
         if (props.dataContext.cell.value != null) {
             if (props.dataContext.cell.value.length === 0) return <></>;
             const value = props.dataContext.cell.value[0];
-            var grid = this.grid;
+            let grid = this.grid;
             return (
         <>
             <IgrExpansionPanel>

--- a/samples/grids/grid/cascading-combo/src/index.tsx
+++ b/samples/grids/grid/cascading-combo/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrComboModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { WorldCitiesAbove500KItem, WorldCitiesAbove500K } from './WorldCitiesAbove500K';
@@ -12,7 +11,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrComboModule
 ];
 mods.forEach((m) => m.register());
@@ -143,7 +141,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridCountryDropDownTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         if (cell === undefined) {
             return <></>;
         }
@@ -158,7 +156,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridRegionDropDownTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         if (cell === undefined) {
             return <></>;
         }
@@ -176,7 +174,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridCityDropDownTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         if (cell === undefined) {
             return <></>;
         }

--- a/samples/grids/grid/cell-editing-sample/src/index.tsx
+++ b/samples/grids/grid/cell-editing-sample/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrSelectModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebSelectDescriptionModule } from 'igniteui-react-core';
@@ -13,7 +12,6 @@ import { IgrSelect, IgrSelectItem } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrSelectModule
 ];
 mods.forEach((m) => m.register());
@@ -92,7 +90,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebSelectDescriptionModule.register(context);
         }

--- a/samples/grids/grid/cell-editing-styling/src/index.tsx
+++ b/samples/grids/grid/cell-editing-styling/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrPaginatorModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebPaginatorDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrPaginatorModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -102,7 +95,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebPaginatorDescriptionModule.register(context);
         }

--- a/samples/grids/grid/cell-selection-mode/src/index.tsx
+++ b/samples/grids/grid/cell-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -106,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/cell-selection-style/src/index.tsx
+++ b/samples/grids/grid/cell-selection-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/change-icons-custom/src/index.tsx
+++ b/samples/grids/grid/change-icons-custom/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarExporter, IgrGridToolbarHiding, IgrGridToolbarPinning } from 'igniteui-react-grids';
+import { IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarExporter, IgrGridToolbarHiding, IgrGridToolbarPinning } from 'igniteui-react-grids';
 import { IgrGrid, IgrPinningConfig, RowPinningPosition, IgrActionStrip, IgrGridPinningActions, IgrGridEditingActions, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import { NwindDataItem, NwindDataItem_LocationsItem, NwindData } from './NwindData';
@@ -12,10 +12,6 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import { IgrButtonGroup, IgrComponentValueChangedEventArgs, IgrIcon, IgrIconMeta, IgrToggleButton, setIconRef, registerIconFromText } from 'igniteui-react';
 import { arrowDown, arrowUp, caretDown, chevronRight, ellipsisRight, eye, eyeSlash, fileExport, filter, magnifyGlass, thumbtack, thumbtackSlash, xMark } from './icons';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/clipboard-operations/src/index.tsx
+++ b/samples/grids/grid/clipboard-operations/src/index.tsx
@@ -3,16 +3,12 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrButton, IgrInput, IgrSwitch, IgrCheckboxChangeEventArgs, IgrComponentDataValueChangedEventArgs, IgrComponentValueChangedEventArgs } from 'igniteui-react';
-import { IgrGridModule, IgrColumnComponentEventArgs } from 'igniteui-react-grids';
+import { IgrColumnComponentEventArgs } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { NwindData } from './NwindData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default function App() {
     let defaultSeparator = " ";

--- a/samples/grids/grid/column-auto-sizing/src/index.tsx
+++ b/samples/grids/grid/column-auto-sizing/src/index.tsx
@@ -2,16 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/column-collapsible-groups/src/index.tsx
+++ b/samples/grids/grid/column-collapsible-groups/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumnGroup, IgrColumn } from 'igniteui-react-grids';
 import { InvoicesDataItem, InvoicesData } from './InvoicesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/column-data-types/src/index.tsx
+++ b/samples/grids/grid/column-data-types/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { InvoicesDataExtendedDates } from './InvoicesDataExtendedDates';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -23,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "";
             columnPipeArgs1.digitsInfo = "1.4-4";
 
@@ -35,7 +30,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.format = "long";
             columnPipeArgs2.timezone = "UTC+0";
 
@@ -47,7 +42,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs3(): IgrColumnPipeArgs {
         if (this._columnPipeArgs3 == null)
         {
-            var columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs3.format = "mediumDate";
 
             this._columnPipeArgs3 = columnPipeArgs3;
@@ -58,7 +53,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs4(): IgrColumnPipeArgs {
         if (this._columnPipeArgs4 == null)
         {
-            var columnPipeArgs4: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs4: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs4.format = "shortTime";
             columnPipeArgs4.timezone = "UTC+0";
 
@@ -70,7 +65,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs5(): IgrColumnPipeArgs {
         if (this._columnPipeArgs5 == null)
         {
-            var columnPipeArgs5: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs5: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs5.currencyCode = "";
             columnPipeArgs5.digitsInfo = "1.4-4";
 
@@ -82,7 +77,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs6(): IgrColumnPipeArgs {
         if (this._columnPipeArgs6 == null)
         {
-            var columnPipeArgs6: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs6: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs6.currencyCode = "";
             columnPipeArgs6.digitsInfo = "1.4-4";
 

--- a/samples/grids/grid/column-hiding-options/src/index.tsx
+++ b/samples/grids/grid/column-hiding-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -131,7 +126,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/column-hiding-toolbar-style/src/index.tsx
+++ b/samples/grids/grid/column-hiding-toolbar-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -135,7 +130,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/column-hiding-toolbar/src/index.tsx
+++ b/samples/grids/grid/column-hiding-toolbar/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -131,7 +126,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/column-moving-options/src/index.tsx
+++ b/samples/grids/grid/column-moving-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrBadgeModule } from 'igniteui-react';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { FinancialDataAllItem, FinancialDataAll } from './FinancialDataAll';
 import { IgrColumnTemplateContext, IgrCellTemplateContext } from 'igniteui-react-grids';
@@ -12,8 +11,7 @@ import { IgrBadge } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrBadgeModule,
-    IgrGridModule
+    IgrBadgeModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -39,7 +37,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.currencyCode = "USD";
             columnPipeArgs2.digitsInfo = "1.2-2";
 
@@ -51,7 +49,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs3(): IgrColumnPipeArgs {
         if (this._columnPipeArgs3 == null)
         {
-            var columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs3.currencyCode = "USD";
             columnPipeArgs3.digitsInfo = "1.2-2";
 
@@ -165,7 +163,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridCurrencyCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         const isCellCurrencyUp = typeof cell.value === 'number' && cell.value > 0;
         const isCellCurrencyDown = typeof cell.value === 'number' && cell.value <= 0;
 
@@ -185,8 +183,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var grid = this.grid;
-        var col = grid.getColumnByName(field);
+        let grid = this.grid;
+        let col = grid.getColumnByName(field);
         col.pinned = !col.pinned;
         grid.markForCheck();
     }

--- a/samples/grids/grid/column-moving-styles/src/index.tsx
+++ b/samples/grids/grid/column-moving-styles/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrBadgeModule } from 'igniteui-react';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { FinancialDataAllItem, FinancialDataAll } from './FinancialDataAll';
 import { IgrColumnTemplateContext, IgrCellTemplateContext } from 'igniteui-react-grids';
@@ -12,8 +11,7 @@ import { IgrBadge } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrBadgeModule,
-    IgrGridModule
+    IgrBadgeModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -39,7 +37,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.currencyCode = "USD";
             columnPipeArgs2.digitsInfo = "1.2-2";
 
@@ -51,7 +49,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs3(): IgrColumnPipeArgs {
         if (this._columnPipeArgs3 == null)
         {
-            var columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs3.currencyCode = "USD";
             columnPipeArgs3.digitsInfo = "1.2-2";
 
@@ -159,7 +157,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridCurrencyCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         const isCellCurrencyUp = typeof cell.value === 'number' && cell.value > 0;
         const isCellCurrencyDown = typeof cell.value === 'number' && cell.value <= 0;
 
@@ -179,8 +177,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var grid = this.grid;
-        var col = grid.getColumnByName(field);
+        let grid = this.grid;
+        let col = grid.getColumnByName(field);
         col.pinned = !col.pinned;
         grid.markForCheck();
     }

--- a/samples/grids/grid/column-pinning-options/src/index.tsx
+++ b/samples/grids/grid/column-pinning-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -124,8 +119,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var grid = this.grid;
-        var col = grid.getColumnByName(field);
+        let grid = this.grid;
+        let col = grid.getColumnByName(field);
         col.pinned = !col.pinned;
         grid.markForCheck();
     }

--- a/samples/grids/grid/column-pinning-right-side/src/index.tsx
+++ b/samples/grids/grid/column-pinning-right-side/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrAvatarModule } from 'igniteui-react';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPinningConfig, ColumnPinningPosition, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { AthletesDataExtendedItem, AthletesDataExtended } from './AthletesDataExtended';
 import { IgrCellTemplateContext } from 'igniteui-react-grids';
@@ -12,8 +11,7 @@ import { IgrAvatar } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrAvatarModule,
-    IgrGridModule
+    IgrAvatarModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.columns = ColumnPinningPosition.End;
 
             this._pinningConfig1 = pinningConfig1;

--- a/samples/grids/grid/column-pinning-styles/src/index.tsx
+++ b/samples/grids/grid/column-pinning-styles/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/column-pinning/src/index.tsx
+++ b/samples/grids/grid/column-pinning/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import CustomersDataLocal from './CustomersDataLocal.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/column-resize-styling/src/index.tsx
+++ b/samples/grids/grid/column-resize-styling/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { AthletesDataItem, AthletesData } from './AthletesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -81,7 +76,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/column-resizing/src/index.tsx
+++ b/samples/grids/grid/column-resizing/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 import { IgrGridBaseDirective, IgrColumnResizeEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -106,9 +101,9 @@ export default class Sample extends React.Component<any, any> {
 
 
     public webGridColumnResized(args: IgrColumnResizeEventArgs): void {
-        var col = args.detail.column;
-        var pWidth = args.detail.prevWidth;
-        var nWidth = args.detail.newWidth;
+        let col = args.detail.column;
+        let pWidth = args.detail.prevWidth;
+        let nWidth = args.detail.newWidth;
     }
 
 }

--- a/samples/grids/grid/column-selection-group/src/index.tsx
+++ b/samples/grids/grid/column-selection-group/src/index.tsx
@@ -1,18 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-
-import { IgrGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumnGroup, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
-
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/column-selection-mode/src/index.tsx
+++ b/samples/grids/grid/column-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -111,7 +109,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/column-selection-styles/src/index.tsx
+++ b/samples/grids/grid/column-selection-styles/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/column-sorting-indicators/src/index.tsx
+++ b/samples/grids/grid/column-sorting-indicators/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrSortingExpression, SortingDirection, IgrColumn } from 'igniteui-react-grids';
 import { FinancialDataAllItem, FinancialDataAll } from './FinancialDataAll';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -24,37 +19,37 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.fieldName = "Settlement";
             sortingExpression2.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression2)
-            var sortingExpression3: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression3: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression3.dir = SortingDirection.Desc;
             sortingExpression3.fieldName = "Type";
             sortingExpression3.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression3)
-            var sortingExpression4: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression4: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression4.dir = SortingDirection.Asc;
             sortingExpression4.fieldName = "Region";
             sortingExpression4.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression4)
-            var sortingExpression5: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression5: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression5.dir = SortingDirection.Asc;
             sortingExpression5.fieldName = "Country";
             sortingExpression5.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression5)
-            var sortingExpression6: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression6: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression6.dir = SortingDirection.Asc;
             sortingExpression6.fieldName = "Price";
             sortingExpression6.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression6)
-            var sortingExpression7: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression7: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression7.dir = SortingDirection.Asc;
             sortingExpression7.fieldName = "Buy";
             sortingExpression7.ignoreCase = true;

--- a/samples/grids/grid/column-sorting-options/src/index.tsx
+++ b/samples/grids/grid/column-sorting-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -38,7 +36,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.fieldName = "Category";
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.ignoreCase = true;
@@ -52,7 +50,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -166,7 +164,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -174,12 +172,12 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridClearSort(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
-        var grid = this.grid;
+        let grid = this.grid;
         grid.clearSort("");
     }
 
     public webGridClearGrouping(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
-        var grid = this.grid;
+        let grid = this.grid;
         grid.clearGrouping("");
     }
 

--- a/samples/grids/grid/column-sorting-style/src/index.tsx
+++ b/samples/grids/grid/column-sorting-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { ProductSalesItem, ProductSales } from './ProductSales';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -25,7 +20,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.fieldName = "Category";
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.ignoreCase = true;
@@ -39,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -120,7 +115,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/conditional-cell-style-1/src/index.tsx
+++ b/samples/grids/grid/conditional-cell-style-1/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { AthletesDataItem, AthletesData } from './AthletesData';
 import { IgrCellTemplateContext } from 'igniteui-react-grids';
@@ -11,8 +10,7 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 

--- a/samples/grids/grid/conditional-cell-style-2/src/index.tsx
+++ b/samples/grids/grid/conditional-cell-style-2/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { AthletesDataItem, AthletesData } from './AthletesData';
@@ -11,10 +10,6 @@ import { IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -78,7 +73,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/conditional-row-selectors/src/index.tsx
+++ b/samples/grids/grid/conditional-row-selectors/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
@@ -10,10 +9,6 @@ import { IgrRowSelectionEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -84,7 +79,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -96,7 +91,7 @@ export default class Sample extends React.Component<any, any> {
             // ignore de-select
             return;
         }
-        var grid = this.grid;
+        let grid = this.grid;
         const originalAddedLength = event.added.length;
 
         // only allow selection of items that contain 'A'

--- a/samples/grids/grid/data-batch-editing-actions/src/index.tsx
+++ b/samples/grids/grid/data-batch-editing-actions/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -16,8 +15,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -154,7 +152,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -163,7 +161,7 @@ export default class Sample extends React.Component<any, any> {
 
     public webGridAddRow(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
-        var grid = this.grid;
+        let grid = this.grid;
         const randomInteger = (start: number, end: number) => Math.floor(Math.random() * (end - start + 1)) + start;
         const randomFloat = (start: number, end: number) => Math.random() * (end - start) + start;
 
@@ -171,9 +169,9 @@ export default class Sample extends React.Component<any, any> {
         if (!(grid as any).__productId) {
             (grid as any).__productId = 0;
         }
-        var year = randomInteger(2000, 2050);
-        var month = randomInteger(0, 11);
-        var day = randomInteger(1, 25);
+        let year = randomInteger(2000, 2050);
+        let month = randomInteger(0, 11);
+        let day = randomInteger(1, 25);
         grid.addRow({
             CategoryID: randomInteger(1, 10),
             Discontinued: randomInteger(1, 10) % 2 === 0,
@@ -194,7 +192,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridUndo(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
 
-        var grid = this.grid;
+        let grid = this.grid;
         //grid.endEdit(true);
         //grid.transactions.undo();
 
@@ -203,7 +201,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridRedo(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
 
-        var grid = this.grid;
+        let grid = this.grid;
 
         //grid.endEdit(true);
         //grid.transactions.redo();
@@ -213,7 +211,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridCommit(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
 
-        var grid = this.grid;
+        let grid = this.grid;
 
         // grid.transactions.commit(grid.data);
         //dialog.close();
@@ -222,7 +220,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridDeleteCellTemplate = (e: {dataContext: IgrCellTemplateContext}) => {
-        var grid = this.grid;
+        let grid = this.grid;
         const id = e.dataContext.cell.id.rowID;
         return<><div onClick={(e: any) => grid.deleteRow(id)}><IgrButton><span key="btnText">Delete</span></IgrButton></div></>;
     }

--- a/samples/grids/grid/data-performance-virtualization/src/index.tsx
+++ b/samples/grids/grid/data-performance-virtualization/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrBadgeModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { FinancialDataAllItem, FinancialDataAll } from './FinancialDataAll';
@@ -12,7 +11,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrBadgeModule
 ];
 mods.forEach((m) => m.register());
@@ -145,7 +143,7 @@ export default class Sample extends React.Component<any, any> {
 
 
     public webGridCurrencyCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         const isCellCurrencyUp = typeof cell.value === 'number' && cell.value > 0;
         const isCellCurrencyDown = typeof cell.value === 'number' && cell.value <= 0;
 

--- a/samples/grids/grid/data-summary-formatter/src/index.tsx
+++ b/samples/grids/grid/data-summary-formatter/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 import { IgrSummaryResult, IgrSummaryOperand } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/data-summary-options/src/index.tsx
+++ b/samples/grids/grid/data-summary-options/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -10,10 +9,6 @@ import { IgrSummaryResult } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -84,7 +79,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/data-summary-template/src/index.tsx
+++ b/samples/grids/grid/data-summary-template/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -147,7 +145,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -157,16 +155,16 @@ export default class Sample extends React.Component<any, any> {
     public webGridHasSummariesChange(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
         let newValue = sender.primitiveValue as boolean;
         const grid = this.grid;
-        var column1 = grid.getColumnByName("UnitsInStock");
-        var column2 = grid.getColumnByName("OrderDate");
+        let column1 = grid.getColumnByName("UnitsInStock");
+        let column2 = grid.getColumnByName("OrderDate");
 
         column1.hasSummary = newValue;
         column2.hasSummary = newValue;
     }
 
     public webGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("grid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("grid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/grid/data-validation-style/src/index.tsx
+++ b/samples/grids/grid/data-validation-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -69,7 +64,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/data-validator-service-cross-field/src/index.tsx
+++ b/samples/grids/grid/data-validator-service-cross-field/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -11,8 +10,7 @@ import NwindData from './NwindData.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -94,7 +92,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/data-validator-service-extended/src/index.tsx
+++ b/samples/grids/grid/data-validator-service-extended/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -140,7 +138,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -150,7 +148,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridUndo(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
 
-        var grid = this.grid;
+        let grid = this.grid;
         //grid.endEdit(true);
         //grid.transactions.undo();
 
@@ -159,7 +157,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridRedo(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
 
-        var grid = this.grid;
+        let grid = this.grid;
 
         //grid.endEdit(true);
         //grid.transactions.redo();
@@ -169,7 +167,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridCommit(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
         //TODO
 
-        var grid = this.grid;
+        let grid = this.grid;
 
         // grid.transactions.commit(grid.data);
         //dialog.close();

--- a/samples/grids/grid/data-validator-service/src/index.tsx
+++ b/samples/grids/grid/data-validator-service/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -36,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.format = "longDate";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -165,7 +163,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/editing-columns/src/index.tsx
+++ b/samples/grids/grid/editing-columns/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrPaginatorModule } from 'igniteui-react-grids';
 import { IgrInputModule } from 'igniteui-react';
 import { IgrGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebPaginatorDescriptionModule, WebInputDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,6 @@ import { IgrInput } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
-    IgrPaginatorModule,
     IgrInputModule
 ];
 mods.forEach((m) => m.register());
@@ -110,7 +107,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebPaginatorDescriptionModule.register(context);
             WebInputDescriptionModule.register(context);

--- a/samples/grids/grid/editing-events/src/index.tsx
+++ b/samples/grids/grid/editing-events/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -10,10 +9,6 @@ import { IgrGridEditEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -78,14 +73,14 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
     }
 
     public webGridEditingEventsCellEdit(args: IgrGridEditEventArgs): void {
-        var d = args.detail;
+        let d = args.detail;
 
         if (d.column != null && d.column.field == "UnitsOnOrder") {
             if (d.newValue > d.rowData.UnitsInStock) {

--- a/samples/grids/grid/editing-lifecycle/src/index.tsx
+++ b/samples/grids/grid/editing-lifecycle/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 import { IgrRowSelectionEventArgs, IgrGridEditEventArgs, IgrGridEditDoneEventArgs } from 'igniteui-react-grids';
@@ -10,10 +9,6 @@ import { IgrComponentBoolValueChangedEventArgs } from 'igniteui-react';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -104,7 +99,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridRowEditEnter(args: IgrGridEditEventArgs): void {
         let container = document.getElementById("container");
         const message = document.createElement("p");
-        message.textContent = `=> 'rowEditEnter' with 'RowID':` + args.detail.rowID;
+        message.textContent = `=> 'rowEditEnter' with 'RowID':` + args.detail.rowKey;
         container.appendChild(message);
     }
 

--- a/samples/grids/grid/excel-exporting/src/index.tsx
+++ b/samples/grids/grid/excel-exporting/src/index.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrGridToolbarModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { InvoicesDataItem, InvoicesData } from './InvoicesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrGridToolbarModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -25,13 +18,13 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.fieldName = "ShipCountry";
             groupingExpression2.ignoreCase = false;
             groupingExpression2.dir = SortingDirection.Asc;
 
             groupingExpression1.push(groupingExpression2)
-            var groupingExpression3: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression3: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression3.fieldName = "ShipCity";
             groupingExpression3.ignoreCase = false;
             groupingExpression3.dir = SortingDirection.Asc;

--- a/samples/grids/grid/excel-style-filtering-sample-1/src/index.tsx
+++ b/samples/grids/grid/excel-style-filtering-sample-1/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -36,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.2-2";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -47,7 +45,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.format = "MM/dd/YYYY";
 
             this._columnPipeArgs2 = columnPipeArgs2;
@@ -148,7 +146,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -156,8 +154,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("grid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("grid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/grid/excel-style-filtering-sample-2/src/index.tsx
+++ b/samples/grids/grid/excel-style-filtering-sample-2/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -12,8 +11,7 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.2-2";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -38,7 +36,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.format = "MM/dd/YYYY";
 
             this._columnPipeArgs2 = columnPipeArgs2;
@@ -122,7 +120,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/excel-style-filtering-sample-3/src/index.tsx
+++ b/samples/grids/grid/excel-style-filtering-sample-3/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -12,8 +11,7 @@ import { IgrGridHeaderTemplateContext, IgrCellTemplateContext } from 'igniteui-r
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.2-2";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -38,7 +36,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.format = "MM/dd/YYYY";
 
             this._columnPipeArgs2 = columnPipeArgs2;
@@ -114,7 +112,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/excel-style-filtering-style/src/index.tsx
+++ b/samples/grids/grid/excel-style-filtering-style/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -12,8 +11,7 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.2-2";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -38,7 +36,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.format = "MM/dd/YYYY";
 
             this._columnPipeArgs2 = columnPipeArgs2;
@@ -114,7 +112,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/external-advanced-filtering/src/index.tsx
+++ b/samples/grids/grid/external-advanced-filtering/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -11,8 +10,7 @@ import NwindData from './NwindData.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -73,7 +71,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/filtering-options/src/index.tsx
+++ b/samples/grids/grid/filtering-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -11,8 +10,7 @@ import NwindData from './NwindData.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -79,7 +77,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/filtering-strategy/src/index.tsx
+++ b/samples/grids/grid/filtering-strategy/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/filtering-style/src/index.tsx
+++ b/samples/grids/grid/filtering-style/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -36,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.2-2";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -47,7 +45,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.format = "MM/dd/YYYY";
 
             this._columnPipeArgs2 = columnPipeArgs2;
@@ -148,7 +146,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -156,8 +154,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("grid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("grid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/grid/groupby-custom/src/index.tsx
+++ b/samples/grids/grid/groupby-custom/src/index.tsx
@@ -2,7 +2,7 @@ import React, { KeyboardEvent, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 
-import { IgrGridModule, IgrGroupByRowTemplateContext, SortingDirection } from "igniteui-react-grids";
+import { IgrGroupByRowTemplateContext, SortingDirection } from "igniteui-react-grids";
 import { IgrGrid, IgrColumn } from "igniteui-react-grids";
 import { InvoicesWorldData } from "./InvoicesWorldData";
 
@@ -15,7 +15,7 @@ import {
   IgrDropdownModule
 } from "igniteui-react";
 
-const mods: any[] = [IgrGridModule, IgrDropdownModule];
+const mods: any[] = [IgrDropdownModule];
 mods.forEach((m) => m.register());
 
 const data = new InvoicesWorldData();

--- a/samples/grids/grid/groupby-expressions/src/index.tsx
+++ b/samples/grids/grid/groupby-expressions/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrColumn } from 'igniteui-react-grids';
 import { InvoicesWorldDataItem, InvoicesWorldData } from './InvoicesWorldData';
 import { IgrGroupByRowTemplateContext, IgrCellTemplateContext } from 'igniteui-react-grids';
@@ -10,10 +9,6 @@ import { IgrBadge } from 'igniteui-react';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -26,13 +21,13 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.fieldName = "ShipCountry";
             groupingExpression2.ignoreCase = false;
             groupingExpression2.dir = SortingDirection.Asc;
 
             groupingExpression1.push(groupingExpression2)
-            var groupingExpression3: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression3: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression3.fieldName = "ShipCity";
             groupingExpression3.ignoreCase = false;
             groupingExpression3.dir = SortingDirection.Asc;

--- a/samples/grids/grid/groupby-paging/src/index.tsx
+++ b/samples/grids/grid/groupby-paging/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { InvoicesWorldDataItem, InvoicesWorldData } from './InvoicesWorldData';
 import { IgrGroupByRowTemplateContext } from 'igniteui-react-grids';
@@ -10,10 +9,6 @@ import { IgrBadge } from 'igniteui-react';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -26,7 +21,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.dir = SortingDirection.Asc;
             groupingExpression2.fieldName = "ShipCountry";
             groupingExpression2.ignoreCase = false;

--- a/samples/grids/grid/groupby-styling/src/index.tsx
+++ b/samples/grids/grid/groupby-styling/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { InvoicesDataItem, InvoicesData } from './InvoicesData';
@@ -10,10 +9,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -26,13 +21,13 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.dir = SortingDirection.Asc;
             groupingExpression2.fieldName = "ShipCountry";
             groupingExpression2.ignoreCase = false;
 
             groupingExpression1.push(groupingExpression2)
-            var groupingExpression3: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression3: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression3.dir = SortingDirection.Asc;
             groupingExpression3.fieldName = "ShipCity";
             groupingExpression3.ignoreCase = false;
@@ -46,7 +41,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.2-2";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -159,7 +154,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/groupby-summary-options/src/index.tsx
+++ b/samples/grids/grid/groupby-summary-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -37,7 +35,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.fieldName = "ShipCountry";
             groupingExpression2.ignoreCase = false;
             groupingExpression2.dir = SortingDirection.Asc;
@@ -51,7 +49,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -148,7 +146,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/groupby-summary-styling/src/index.tsx
+++ b/samples/grids/grid/groupby-summary-styling/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -36,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.dir = SortingDirection.Asc;
             groupingExpression2.fieldName = "ShipCountry";
             groupingExpression2.ignoreCase = false;
@@ -50,7 +48,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -143,7 +141,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/keyboard-custom-navigation/src/index.tsx
+++ b/samples/grids/grid/keyboard-custom-navigation/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -12,8 +11,7 @@ import { IgrGridKeydownEventArgs } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -86,7 +84,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/keyboard-mrl-navigation/src/index.tsx
+++ b/samples/grids/grid/keyboard-mrl-navigation/src/index.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrColumnLayoutModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumnLayout, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebColumnLayoutDescriptionModule } from 'igniteui-react-core';
 import { CompanyDataItem, CompanyData } from './CompanyData';
 import { IgrGridKeydownEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrColumnLayoutModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -150,7 +143,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebColumnLayoutDescriptionModule.register(context);
         }

--- a/samples/grids/grid/layout-display-density/src/index.tsx
+++ b/samples/grids/grid/layout-display-density/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -209,7 +207,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -217,8 +215,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("grid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("grid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/grid/master-detail/src/index.tsx
+++ b/samples/grids/grid/master-detail/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 import { IgrGridMasterDetailContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/multi-cell-selection-mode/src/index.tsx
+++ b/samples/grids/grid/multi-cell-selection-mode/src/index.tsx
@@ -2,15 +2,11 @@ import React, { useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrColumn, IgrGrid, IgrGridModule, IgrGridSelectionRangeEventArgs } from 'igniteui-react-grids';
+import { IgrColumn, IgrGrid, IgrGridSelectionRangeEventArgs } from 'igniteui-react-grids';
 import { InvoicesData } from './InvoicesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 const icon = `<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 -960 960 960" width="48"><path d="M180-81q-24 0-42-18t-18-42v-603h60v603h474v60H180Zm120-120q-24 0-42-18t-18-42v-560q0-24 18-42t42-18h440q24 0 42 18t18 42v560q0 24-18 42t-42 18H300Zm0-60h440v-560H300v560Zm0 0v-560 560Z"/></svg>`;
 
 export default function App() {

--- a/samples/grids/grid/multi-column-headers-export/src/index.tsx
+++ b/samples/grids/grid/multi-column-headers-export/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrGridToolbarModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebGridToolbarDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
@@ -10,11 +9,6 @@ import { IgrExporterEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule,
-    IgrGridToolbarModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -148,7 +142,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebGridToolbarDescriptionModule.register(context);
         }

--- a/samples/grids/grid/multi-column-headers-overview/src/index.tsx
+++ b/samples/grids/grid/multi-column-headers-overview/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
@@ -14,8 +13,6 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
-    IgrColumnGroupModule,
     IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
@@ -163,7 +160,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
             PropertyEditorPanelDescriptionModule.register(context);

--- a/samples/grids/grid/multi-column-headers-styling/src/index.tsx
+++ b/samples/grids/grid/multi-column-headers-styling/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebColumnGroupDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -126,7 +119,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
         }

--- a/samples/grids/grid/multi-column-headers-template/src/index.tsx
+++ b/samples/grids/grid/multi-column-headers-template/src/index.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebColumnGroupDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -142,7 +135,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
         }

--- a/samples/grids/grid/multi-row-layout-options/src/index.tsx
+++ b/samples/grids/grid/multi-row-layout-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGroupingExpression, SortingDirection, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarPinning, IgrGridToolbarHiding, IgrColumnLayout, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -25,7 +20,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._groupingExpression1 == null)
         {
             let groupingExpression1: IgrGroupingExpression[] = [];
-            var groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
+            let groupingExpression2: IgrGroupingExpression = {} as IgrGroupingExpression;
             groupingExpression2.fieldName = "Country";
             groupingExpression2.ignoreCase = false;
             groupingExpression2.dir = SortingDirection.Asc;
@@ -195,7 +190,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/multi-row-layout-style/src/index.tsx
+++ b/samples/grids/grid/multi-row-layout-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumnLayout, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -154,7 +149,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/overview/src/index.tsx
+++ b/samples/grids/grid/overview/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/paste/src/index.tsx
+++ b/samples/grids/grid/paste/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -130,7 +128,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -138,8 +136,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridPasteModeChange(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var item = sender as IgrPropertyEditorPropertyDescription;
-        var newVal = item.primitiveValue;
+        let item = sender as IgrPropertyEditorPropertyDescription;
+        let newVal = item.primitiveValue;
         (this as any)["pasteMode"] = newVal === "NewRecords" ? "Paste data as new records" : "Paste starting from active cell";
     }
 
@@ -184,10 +182,9 @@ export default class Sample extends React.Component<any, any> {
         let data;
         const clData: any = "clipboardData";
 
-        // get clipboard data - from window.cliboardData for IE or from the original event's arguments.
-        if (window[clData]  as any) {
-            (window.event as any).returnValue = false;
-            data = (window[clData]  as any).getData("text");
+        if (window[clData] as any) {
+            eventArgs.returnValue = false;
+            data = (window[clData] as any).getData("text");
         } else {
             data = eventArgs[clData].getData("text/plain");
         }

--- a/samples/grids/grid/remote-paging-data/src/index.tsx
+++ b/samples/grids/grid/remote-paging-data/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
@@ -11,8 +10,7 @@ import NwindData from './NwindData.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -84,7 +82,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/row-adding/src/index.tsx
+++ b/samples/grids/grid/row-adding/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrActionStrip, IgrGridEditingActions, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -97,7 +92,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/row-classes/src/index.tsx
+++ b/samples/grids/grid/row-classes/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 import { IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/row-editing-options/src/index.tsx
+++ b/samples/grids/grid/row-editing-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -23,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.format = "mediumDate";
 
             this._columnPipeArgs1 = columnPipeArgs1;

--- a/samples/grids/grid/row-editing-style/src/index.tsx
+++ b/samples/grids/grid/row-editing-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -23,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.format = "mediumDate";
 
             this._columnPipeArgs1 = columnPipeArgs1;

--- a/samples/grids/grid/row-paging-basic/src/index.tsx
+++ b/samples/grids/grid/row-paging-basic/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrLinearProgressModule } from 'igniteui-react';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPaginator, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { AthletesDataItem, AthletesData } from './AthletesData';
 import { IgrCellTemplateContext } from 'igniteui-react-grids';
@@ -12,8 +11,7 @@ import { IgrLinearProgress } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrLinearProgressModule,
-    IgrGridModule
+    IgrLinearProgressModule
 ];
 mods.forEach((m) => m.register());
 
@@ -27,7 +25,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.1-5";
 
             this._columnPipeArgs1 = columnPipeArgs1;

--- a/samples/grids/grid/row-paging-options/src/index.tsx
+++ b/samples/grids/grid/row-paging-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPaginator, IgrPaginatorResourceStrings, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -30,7 +28,7 @@ export default class Sample extends React.Component<any, any> {
     public get paginatorResourceStrings1(): IgrPaginatorResourceStrings {
         if (this._paginatorResourceStrings1 == null)
         {
-            var paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
+            let paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
             paginatorResourceStrings1.igx_paginator_label = "Records per page";
 
             this._paginatorResourceStrings1 = paginatorResourceStrings1;
@@ -41,7 +39,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.digitsInfo = "1.1-5";
 
             this._columnPipeArgs1 = columnPipeArgs1;
@@ -133,7 +131,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -141,8 +139,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("grid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("grid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/grid/row-pinning-drag/src/index.tsx
+++ b/samples/grids/grid/row-pinning-drag/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPinningConfig, RowPinningPosition, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import CustomersDataLocal from './CustomersDataLocal.json';
@@ -11,8 +10,7 @@ import CustomersDataLocal from './CustomersDataLocal.json';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -26,7 +24,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -95,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/row-pinning-extra-column/src/index.tsx
+++ b/samples/grids/grid/row-pinning-extra-column/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import CustomersDataLocal from './CustomersDataLocal.json';
@@ -12,8 +11,7 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -95,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/row-pinning-options/src/index.tsx
+++ b/samples/grids/grid/row-pinning-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrPinningConfig, RowPinningPosition, IgrColumn, IgrActionStrip, IgrGridPinningActions } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -35,7 +33,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -138,7 +136,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -146,9 +144,9 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridSetRowPinning(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var item = sender as IgrPropertyEditorPropertyDescription;
-        var newVal = item.primitiveValue;
-        var grid = this.grid;
+        let item = sender as IgrPropertyEditorPropertyDescription;
+        let newVal = item.primitiveValue;
+        let grid = this.grid;
         grid.pinning.rows = newVal === "Top" ? RowPinningPosition.Top : RowPinningPosition.Bottom;
     }
 

--- a/samples/grids/grid/row-pinning-style/src/index.tsx
+++ b/samples/grids/grid/row-pinning-style/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrActionStripModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPinningConfig, RowPinningPosition, IgrColumn, IgrActionStrip, IgrGridPinningActions } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebActionStripDescriptionModule } from 'igniteui-react-core';
 import CustomersDataLocal from './CustomersDataLocal.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrActionStripModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -25,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -108,7 +101,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebActionStripDescriptionModule.register(context);
         }
@@ -116,7 +109,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridPinRowOnRendered(args: any): void {
-        var grid = this.grid as any;
+        let grid = this.grid as any;
         grid.pinRow("ALFKI");
         grid.pinRow("AROUT");
     }

--- a/samples/grids/grid/row-reorder/src/index.tsx
+++ b/samples/grids/grid/row-reorder/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
@@ -12,8 +11,7 @@ import { IgrRowDragEndEventArgs } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -94,7 +92,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/row-selection-mode/src/index.tsx
+++ b/samples/grids/grid/row-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrBadgeModule } from 'igniteui-react';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
@@ -17,7 +16,6 @@ import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
     IgrBadgeModule,
-    IgrGridModule,
     IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
@@ -39,7 +37,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -51,7 +49,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs2(): IgrColumnPipeArgs {
         if (this._columnPipeArgs2 == null)
         {
-            var columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs2: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs2.currencyCode = "USD";
             columnPipeArgs2.digitsInfo = "1.2-2";
 
@@ -63,7 +61,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs3(): IgrColumnPipeArgs {
         if (this._columnPipeArgs3 == null)
         {
-            var columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs3: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs3.currencyCode = "USD";
             columnPipeArgs3.digitsInfo = "1.2-2";
 
@@ -169,7 +167,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             PropertyEditorPanelDescriptionModule.register(context);
         }
@@ -177,7 +175,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridCurrencyCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         const isCellCurrencyUp = typeof cell.value === 'number' && cell.value > 0;
         const isCellCurrencyDown = typeof cell.value === 'number' && cell.value <= 0;
 

--- a/samples/grids/grid/row-selection-template-excel/src/index.tsx
+++ b/samples/grids/grid/row-selection-template-excel/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrPaginator, IgrPaginatorResourceStrings, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
 import { CustomersDataItem, CustomersData } from './CustomersData';
@@ -12,8 +11,7 @@ import { IgrRowSelectorTemplateContext, IgrHeadSelectorTemplateContext } from 'i
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -28,7 +26,7 @@ export default class Sample extends React.Component<any, any> {
     public get paginatorResourceStrings1(): IgrPaginatorResourceStrings {
         if (this._paginatorResourceStrings1 == null)
         {
-            var paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
+            let paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
             paginatorResourceStrings1.igx_paginator_label = "Items per page";
 
             this._paginatorResourceStrings1 = paginatorResourceStrings1;
@@ -99,7 +97,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }

--- a/samples/grids/grid/row-selection-template-numbers/src/index.tsx
+++ b/samples/grids/grid/row-selection-template-numbers/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrCheckboxModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebCheckboxDescriptionModule } from 'igniteui-react-core';
@@ -13,7 +12,6 @@ import { IgrCheckbox } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrCheckboxModule
 ];
 mods.forEach((m) => m.register());
@@ -77,7 +75,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebCheckboxDescriptionModule.register(context);
         }

--- a/samples/grids/grid/row-styles/src/index.tsx
+++ b/samples/grids/grid/row-styles/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrBadgeModule } from 'igniteui-react';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 import { FinancialDataAllItem, FinancialDataAll } from './FinancialDataAll';
@@ -14,7 +13,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
     IgrBadgeModule
 ];
 mods.forEach((m) => m.register());
@@ -156,7 +154,7 @@ export default class Sample extends React.Component<any, any> {
     };
 
     public webGridCurrencyCellTemplate = (props: {dataContext: IgrCellTemplateContext}) => {
-        var cell = props.dataContext.cell as any;
+        let cell = props.dataContext.cell as any;
         const isCellCurrencyUp = typeof cell.value === 'number' && cell.value > 0;
         const isCellCurrencyDown = typeof cell.value === 'number' && cell.value <= 0;
 

--- a/samples/grids/grid/styling-custom-CSS/src/index.tsx
+++ b/samples/grids/grid/styling-custom-CSS/src/index.tsx
@@ -3,15 +3,10 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { LocalDataItem, LocalData } from './SampleData';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrColumn } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid

--- a/samples/grids/grid/toolbar-sample-1/src/index.tsx
+++ b/samples/grids/grid/toolbar-sample-1/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { AthletesDataItem, AthletesData } from './AthletesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -105,7 +100,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/toolbar-sample-2/src/index.tsx
+++ b/samples/grids/grid/toolbar-sample-2/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { AthletesDataItem, AthletesData } from './AthletesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -105,7 +100,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/toolbar-sample-3/src/index.tsx
+++ b/samples/grids/grid/toolbar-sample-3/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { AthletesDataItem, AthletesData } from './AthletesData';
@@ -10,10 +9,6 @@ import { IgrGridToolbarExportEventArgs, IgrExporterOptionsBase } from 'igniteui-
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -96,7 +91,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/grid/toolbar-style/src/index.tsx
+++ b/samples/grids/grid/toolbar-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { AthletesDataItem, AthletesData } from './AthletesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrGrid
@@ -100,7 +95,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/hierarchical-grid/action-strip/src/index.tsx
+++ b/samples/grids/hierarchical-grid/action-strip/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPinningConfig, RowPinningPosition, IgrActionStrip, IgrGridPinningActions, IgrGridEditingActions, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -23,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;

--- a/samples/grids/hierarchical-grid/advanced-filtering-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/advanced-filtering-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/advanced-filtering-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/advanced-filtering-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid1: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/cell-editing-sample/src/index.tsx
+++ b/samples/grids/hierarchical-grid/cell-editing-sample/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrSelectModule } from 'igniteui-react';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebSelectDescriptionModule } from 'igniteui-react-core';
@@ -13,7 +12,6 @@ import { IgrSelect, IgrSelectItem } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrHierarchicalGridModule,
     IgrSelectModule
 ];
 mods.forEach((m) => m.register());
@@ -106,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebSelectDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/cell-editing-styling/src/index.tsx
+++ b/samples/grids/hierarchical-grid/cell-editing-styling/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrPaginatorModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebPaginatorDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrPaginatorModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -120,7 +113,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebPaginatorDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/cell-selection-mode/src/index.tsx
+++ b/samples/grids/hierarchical-grid/cell-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -146,7 +144,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/cell-selection-overview/src/index.tsx
+++ b/samples/grids/hierarchical-grid/cell-selection-overview/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -198,7 +196,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/cell-selection-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/cell-selection-style/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -198,7 +196,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/column-auto-sizing/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-auto-sizing/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomers from './HierarchicalCustomers.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid1: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-collapsible-groups/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-collapsible-groups/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumnGroup, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomersData from './HierarchicalCustomersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-hiding-toolbar-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-hiding-toolbar-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridToolbarModule, IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridToolbarModule,
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-hiding-toolbar/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-hiding-toolbar/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridToolbarModule, IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridToolbarModule,
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-moving-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-moving-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomers from './HierarchicalCustomers.json';
 import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-moving-styles/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-moving-styles/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomers from './HierarchicalCustomers.json';
 import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-pinning-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-pinning-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomersData from './HierarchicalCustomersData.json';
 import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-pinning-right-side/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-pinning-right-side/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPinningConfig, ColumnPinningPosition, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomersData from './HierarchicalCustomersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -23,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.columns = ColumnPinningPosition.End;
 
             this._pinningConfig1 = pinningConfig1;

--- a/samples/grids/hierarchical-grid/column-pinning-styles/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-pinning-styles/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomersData from './HierarchicalCustomersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-pinning/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-pinning/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomersData from './HierarchicalCustomersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-resize-styling/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-resize-styling/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-resizing/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-resizing/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-selection-group/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-selection-group/src/index.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumnGroup, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import HierarchicalCustomers from './HierarchicalCustomers.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-selection-mode/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -177,7 +175,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/column-selection-styles/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-selection-styles/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/column-sorting-indicators/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-sorting-indicators/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -24,25 +19,25 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.fieldName = "Artist";
             sortingExpression2.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression2)
-            var sortingExpression3: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression3: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression3.dir = SortingDirection.Desc;
             sortingExpression3.fieldName = "Debut";
             sortingExpression3.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression3)
-            var sortingExpression4: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression4: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression4.dir = SortingDirection.Asc;
             sortingExpression4.fieldName = "GrammyNominations";
             sortingExpression4.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression4)
-            var sortingExpression5: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression5: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression5.dir = SortingDirection.Asc;
             sortingExpression5.fieldName = "GrammyAwards";
             sortingExpression5.ignoreCase = true;

--- a/samples/grids/hierarchical-grid/column-sorting-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-sorting-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -24,7 +19,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.fieldName = "Artist";
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.ignoreCase = true;

--- a/samples/grids/hierarchical-grid/column-sorting-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/column-sorting-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -24,7 +19,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.fieldName = "Artist";
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.ignoreCase = true;

--- a/samples/grids/hierarchical-grid/conditional-cell-style-1/src/index.tsx
+++ b/samples/grids/hierarchical-grid/conditional-cell-style-1/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/conditional-cell-style-2/src/index.tsx
+++ b/samples/grids/hierarchical-grid/conditional-cell-style-2/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrPropertyEditorPropertyDescriptionButtonClickEventArgs } from 'igniteui-react-layouts';
@@ -10,10 +9,6 @@ import { IgrGrid, IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/conditional-row-selectors/src/index.tsx
+++ b/samples/grids/hierarchical-grid/conditional-row-selectors/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
 import SingersData from './SingersData.json';
@@ -10,10 +9,6 @@ import { IgrRowSelectionEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -134,7 +129,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -146,7 +141,7 @@ export default class Sample extends React.Component<any, any> {
             // ignore de-select
             return;
         }
-        var grid = this.hierarchicalGrid;
+        let grid = this.hierarchicalGrid;
         const originalAddedLength = event.added.length;
 
         // only allow selection of items that has grammy award

--- a/samples/grids/hierarchical-grid/custom-filtering/src/index.tsx
+++ b/samples/grids/hierarchical-grid/custom-filtering/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/data-exporting-indicator/src/index.tsx
+++ b/samples/grids/hierarchical-grid/data-exporting-indicator/src/index.tsx
@@ -7,7 +7,6 @@ import {
   IgrGridToolbarActions,
   IgrGridToolbarExporter,
   IgrGridToolbarTitle,
-  IgrHierarchicalGridModule,
 } from "igniteui-react-grids";
 import {
   IgrHierarchicalGrid,
@@ -18,8 +17,6 @@ import { IgrButton } from "igniteui-react";
 import { SingersData } from "./SingersData";
 
 import "igniteui-react-grids/grids/themes/light/bootstrap.css";
-
-IgrHierarchicalGridModule.register();
 
 export default function App() {
   const singersData = new SingersData();

--- a/samples/grids/hierarchical-grid/data-summary-formatter/src/index.tsx
+++ b/samples/grids/hierarchical-grid/data-summary-formatter/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrSummaryResult, IgrSummaryOperand } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -160,7 +155,7 @@ export default class Sample extends React.Component<any, any> {
 
 
     public webHierarchicalGridRenderedExpand(args:any): void {
-        var hierarchicalGrid = this.hierarchicalGrid;
+        let hierarchicalGrid = this.hierarchicalGrid;
         hierarchicalGrid.expandAll();
         setTimeout(() => {
             hierarchicalGrid.getColumnByName("Debut").formatter = (value: number) => Math.floor(value / 10) * 10 + 's';

--- a/samples/grids/hierarchical-grid/data-summary-options-styling/src/index.tsx
+++ b/samples/grids/hierarchical-grid/data-summary-options-styling/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/data-summary-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/data-summary-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/data-summary-template/src/index.tsx
+++ b/samples/grids/hierarchical-grid/data-summary-template/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -188,7 +186,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }
@@ -198,9 +196,9 @@ export default class Sample extends React.Component<any, any> {
     public webHierarchicalGridHasSummariesChange(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
         let newValue = sender.primitiveValue as boolean;
         const grid = this.hierarchicalGrid;
-        var column1 = grid.getColumnByName("Photo");
-        var column2 = grid.getColumnByName("GrammyNominations");
-        var column3 = grid.getColumnByName("GrammyAwards");
+        let column1 = grid.getColumnByName("Photo");
+        let column2 = grid.getColumnByName("GrammyNominations");
+        let column3 = grid.getColumnByName("GrammyAwards");
 
         column1.hasSummary = newValue;
         column2.hasSummary = newValue;
@@ -208,8 +206,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webHierarchicalGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("hierarchicalGrid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("hierarchicalGrid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/hierarchical-grid/editing-columns/src/index.tsx
+++ b/samples/grids/hierarchical-grid/editing-columns/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrPaginatorModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebPaginatorDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrPaginatorModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -120,7 +113,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebPaginatorDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/editing-events/src/index.tsx
+++ b/samples/grids/hierarchical-grid/editing-events/src/index.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrPaginatorModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebPaginatorDescriptionModule } from 'igniteui-react-core';
 import NwindData from './NwindData.json';
 import { IgrGrid, IgrGridEditEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrPaginatorModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -132,7 +125,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebPaginatorDescriptionModule.register(context);
         }
@@ -140,7 +133,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridEditingEventsCellEdit(args: IgrGridEditEventArgs): void {
-        var d = args.detail;
+        let d = args.detail;
 
         if (d.column != null && d.column.field == "UnitsOnOrder") {
             if (d.newValue > d.rowData.UnitsInStock) {

--- a/samples/grids/hierarchical-grid/editing-lifecycle/src/index.tsx
+++ b/samples/grids/hierarchical-grid/editing-lifecycle/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrRowSelectionEventArgs, IgrGridEditEventArgs, IgrGridEditDoneEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -152,7 +147,7 @@ export default class Sample extends React.Component<any, any> {
     public webHierarchicalGridRowEditEnter(args: IgrGridEditEventArgs): void {
         let container = document.getElementById("container");
         const message = document.createElement("p");
-        message.textContent = `Hierarchical Grid => 'rowEditEnter' with 'RowID':` + args.detail.rowID;
+        message.textContent = `Hierarchical Grid => 'rowEditEnter' with 'RowID':` + args.detail.rowKey;
         container.appendChild(message);
     }
 
@@ -201,7 +196,7 @@ export default class Sample extends React.Component<any, any> {
     public webRowIslandGridRowEditEnter(args: IgrGridEditEventArgs): void {
         let container = document.getElementById("container");
         const message = document.createElement("p");
-        message.textContent = `Row Island => 'rowEditEnter' with 'RowID':` + args.detail.rowID;
+        message.textContent = `Row Island => 'rowEditEnter' with 'RowID':` + args.detail.rowKey;
         container.appendChild(message);
     }
 

--- a/samples/grids/hierarchical-grid/excel-exporting/src/index.tsx
+++ b/samples/grids/hierarchical-grid/excel-exporting/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridToolbarModule, IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersExportData from './SingersExportData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridToolbarModule,
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/excel-style-filtering-sample-1/src/index.tsx
+++ b/samples/grids/hierarchical-grid/excel-style-filtering-sample-1/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/excel-style-filtering-sample-2/src/index.tsx
+++ b/samples/grids/hierarchical-grid/excel-style-filtering-sample-2/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/excel-style-filtering-sample-3/src/index.tsx
+++ b/samples/grids/hierarchical-grid/excel-style-filtering-sample-3/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrGridHeaderTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/excel-style-filtering-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/excel-style-filtering-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/filtering-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/filtering-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/filtering-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/filtering-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid1: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/hierarchical-grid-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/hierarchical-grid-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrPaginatorResourceStrings, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -24,7 +19,7 @@ export default class Sample extends React.Component<any, any> {
     public get paginatorResourceStrings1(): IgrPaginatorResourceStrings {
         if (this._paginatorResourceStrings1 == null)
         {
-            var paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
+            let paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
             paginatorResourceStrings1.igx_paginator_label = "Records per page";
 
             this._paginatorResourceStrings1 = paginatorResourceStrings1;

--- a/samples/grids/hierarchical-grid/hierarchical-grid-paging-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/hierarchical-grid-paging-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPaginator, IgrPaginatorResourceStrings, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -24,7 +19,7 @@ export default class Sample extends React.Component<any, any> {
     public get paginatorResourceStrings1(): IgrPaginatorResourceStrings {
         if (this._paginatorResourceStrings1 == null)
         {
-            var paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
+            let paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
             paginatorResourceStrings1.igx_paginator_label = "Records per page";
 
             this._paginatorResourceStrings1 = paginatorResourceStrings1;

--- a/samples/grids/hierarchical-grid/hierarchical-grid-styling/src/index.tsx
+++ b/samples/grids/hierarchical-grid/hierarchical-grid-styling/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/layout-display-density/src/index.tsx
+++ b/samples/grids/hierarchical-grid/layout-display-density/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -192,7 +190,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }
@@ -200,8 +198,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webHierarchicalGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("hierarchicalGrid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("hierarchicalGrid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/hierarchical-grid/multi-column-headers-export/src/index.tsx
+++ b/samples/grids/hierarchical-grid/multi-column-headers-export/src/index.tsx
@@ -2,19 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridToolbarModule, IgrColumnGroupModule, IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumnGroup, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import MultiColumnsExportData from './MultiColumnsExportData.json';
 import { IgrExporterEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridToolbarModule,
-    IgrColumnGroupModule,
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/multi-column-headers-overview/src/index.tsx
+++ b/samples/grids/hierarchical-grid/multi-column-headers-overview/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrColumnGroup, IgrRowIsland } from 'igniteui-react-grids';
@@ -14,8 +13,6 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrColumnGroupModule,
     IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
@@ -284,7 +281,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
             PropertyEditorPanelDescriptionModule.register(context);

--- a/samples/grids/hierarchical-grid/multi-column-headers-styling/src/index.tsx
+++ b/samples/grids/hierarchical-grid/multi-column-headers-styling/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrColumnGroup, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebColumnGroupDescriptionModule } from 'igniteui-react-core';
 import HierarchicalCustomers from './HierarchicalCustomers.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -247,7 +240,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/multi-column-headers-template/src/index.tsx
+++ b/samples/grids/hierarchical-grid/multi-column-headers-template/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrColumnGroup, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebColumnGroupDescriptionModule } from 'igniteui-react-core';
 import HierarchicalCustomers from './HierarchicalCustomers.json';
@@ -10,11 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid
@@ -253,7 +247,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/overview/src/index.tsx
+++ b/samples/grids/hierarchical-grid/overview/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/row-adding/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-adding/src/index.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrActionStripModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrActionStrip, IgrGridEditingActions, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrActionStripModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/row-classes/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-classes/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/row-editing-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-editing-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/row-editing-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-editing-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/row-pinning-extra-column/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-pinning-extra-column/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrPinningConfig, RowPinningPosition, ColumnPinningPosition, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -36,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
             pinningConfig1.columns = ColumnPinningPosition.End;
 
@@ -48,7 +46,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig2(): IgrPinningConfig {
         if (this._pinningConfig2 == null)
         {
-            var pinningConfig2: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig2: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig2.rows = RowPinningPosition.Top;
             pinningConfig2.columns = ColumnPinningPosition.End;
 
@@ -60,7 +58,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig3(): IgrPinningConfig {
         if (this._pinningConfig3 == null)
         {
-            var pinningConfig3: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig3: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig3.rows = RowPinningPosition.Top;
             pinningConfig3.columns = ColumnPinningPosition.End;
 
@@ -72,7 +70,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig4(): IgrPinningConfig {
         if (this._pinningConfig4 == null)
         {
-            var pinningConfig4: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig4: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig4.rows = RowPinningPosition.Top;
             pinningConfig4.columns = ColumnPinningPosition.End;
 
@@ -265,7 +263,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/row-pinning-options/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-pinning-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrPinningConfig, RowPinningPosition, ColumnPinningPosition, IgrColumn, IgrActionStrip, IgrGridPinningActions, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -35,7 +33,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
             pinningConfig1.columns = ColumnPinningPosition.End;
 
@@ -48,7 +46,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig2(): IgrPinningConfig {
         if (this._pinningConfig2 == null)
         {
-            var pinningConfig2: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig2: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig2.rows = RowPinningPosition.Top;
             pinningConfig2.columns = ColumnPinningPosition.End;
 
@@ -179,7 +177,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }
@@ -201,7 +199,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webHierarchicalGridPinRowOnRendered(): void {
-        var hierarchicalGrid = this.grid;
+        let hierarchicalGrid = this.grid;
         hierarchicalGrid.pinRow(hierarchicalGrid.data[0].Photo);
         hierarchicalGrid.pinRow(hierarchicalGrid.data[1].Photo);
     }

--- a/samples/grids/hierarchical-grid/row-pinning-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-pinning-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrPinningConfig, RowPinningPosition, ColumnPinningPosition, IgrColumn, IgrActionStrip, IgrGridPinningActions, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrGrid } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid
@@ -24,7 +19,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
             pinningConfig1.columns = ColumnPinningPosition.End;
 
@@ -37,7 +32,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig2(): IgrPinningConfig {
         if (this._pinningConfig2 == null)
         {
-            var pinningConfig2: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig2: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig2.rows = RowPinningPosition.Top;
             pinningConfig2.columns = ColumnPinningPosition.End;
 
@@ -146,7 +141,7 @@ export default class Sample extends React.Component<any, any> {
 
 
     public webHierarchicalGridPinRowOnRendered(): void {
-        var hierarchicalGrid = this.grid;
+        let hierarchicalGrid = this.grid;
         hierarchicalGrid.pinRow(hierarchicalGrid.data[0].Photo);
         hierarchicalGrid.pinRow(hierarchicalGrid.data[1].Photo);
     }

--- a/samples/grids/hierarchical-grid/row-reorder/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-reorder/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrRowDragEndEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/row-selection-mode/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-selection-mode/src/index.tsx
@@ -4,7 +4,6 @@ import './index.css';
 
 import { IgrBadgeModule } from 'igniteui-react';
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebHierarchicalGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
     IgrBadgeModule,
-    IgrPropertyEditorPanelModule,
-    IgrHierarchicalGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -163,7 +161,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebHierarchicalGridDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/row-selection-template-numbers/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-selection-template-numbers/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrCheckboxModule } from 'igniteui-react';
 import { IgrHierarchicalGrid, IgrPaginator, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import { ComponentRenderer, WebHierarchicalGridDescriptionModule, WebCheckboxDescriptionModule } from 'igniteui-react-core';
@@ -13,7 +12,6 @@ import { IgrCheckbox } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrHierarchicalGridModule,
     IgrCheckboxModule
 ];
 mods.forEach((m) => m.register());
@@ -138,7 +136,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebHierarchicalGridDescriptionModule.register(context);
             WebCheckboxDescriptionModule.register(context);
         }

--- a/samples/grids/hierarchical-grid/row-styles/src/index.tsx
+++ b/samples/grids/hierarchical-grid/row-styles/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrPropertyEditorPropertyDescriptionButtonClickEventArgs } from 'igniteui-react-layouts';
@@ -10,10 +9,6 @@ import { IgrGrid, IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/toolbar-sample-3/src/index.tsx
+++ b/samples/grids/hierarchical-grid/toolbar-sample-3/src/index.tsx
@@ -2,18 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrGridToolbarModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 import { IgrExporterOptionsBase, IgrGridToolbarExportEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrGridToolbarModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private hierarchicalGrid: IgrHierarchicalGrid

--- a/samples/grids/hierarchical-grid/toolbar-sample-4/src/index.tsx
+++ b/samples/grids/hierarchical-grid/toolbar-sample-4/src/index.tsx
@@ -7,7 +7,6 @@ import {
   IgrGridToolbarActions,
   IgrGridToolbarHiding,
   IgrGridToolbarTitle,
-  IgrHierarchicalGridModule,
 } from "igniteui-react-grids";
 import {
   IgrHierarchicalGrid,
@@ -19,7 +18,6 @@ import { SingersData } from "./SingersData";
 
 import "igniteui-react-grids/grids/themes/light/bootstrap.css";
 
-IgrHierarchicalGridModule.register();
 IgrIconModule.register();
 
 const icon = `<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 -960 960 960" width="48"><path d="m249-207-42-42 231-231-231-231 42-42 231 231 231-231 42 42-231 231 231 231-42 42-231-231-231 231Z"/></svg>`;

--- a/samples/grids/hierarchical-grid/toolbar-style/src/index.tsx
+++ b/samples/grids/hierarchical-grid/toolbar-style/src/index.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrHierarchicalGridModule, IgrGridToolbarModule } from 'igniteui-react-grids';
 import { IgrHierarchicalGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn, IgrRowIsland } from 'igniteui-react-grids';
 import SingersData from './SingersData.json';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrHierarchicalGridModule,
-    IgrGridToolbarModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrHierarchicalGrid

--- a/samples/grids/pivot-grid/aggregate-max-sales/src/index.tsx
+++ b/samples/grids/pivot-grid/aggregate-max-sales/src/index.tsx
@@ -2,16 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrPivotGridModule } from 'igniteui-react-grids';
 import { IgrPivotGrid, IgrPivotConfiguration, IgrPivotDimension, IgrPivotValue, IgrPivotAggregator } from 'igniteui-react-grids';
 import { PivotSalesDataItem, PivotSalesData } from './PivotSalesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrPivotGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrPivotGrid
@@ -23,22 +17,22 @@ export default class Sample extends React.Component<any, any> {
     public get pivotConfiguration1(): IgrPivotConfiguration {
         if (this._pivotConfiguration1 == null)
         {
-            var pivotConfiguration1: IgrPivotConfiguration = {} as IgrPivotConfiguration;
+            let pivotConfiguration1: IgrPivotConfiguration = {} as IgrPivotConfiguration;
 
-            var igrPivotDimension1: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension1: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension1.memberName = "Country";
             igrPivotDimension1.enabled = true;
 
             pivotConfiguration1.columns = [igrPivotDimension1];
-            var igrPivotDimension2: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension2: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension2.memberName = "Product";
             igrPivotDimension2.enabled = true;
 
             pivotConfiguration1.rows = [igrPivotDimension2];
-            var igrPivotValue1: IgrPivotValue = {} as IgrPivotValue;
+            let igrPivotValue1: IgrPivotValue = {} as IgrPivotValue;
             igrPivotValue1.member = "Sales";
             igrPivotValue1.enabled = true;
-            var igrPivotAggregator1: IgrPivotAggregator = {} as IgrPivotAggregator;
+            let igrPivotAggregator1: IgrPivotAggregator = {} as IgrPivotAggregator;
             igrPivotAggregator1.key = "MAX";
             igrPivotAggregator1.aggregator = this.pivotSalesDataAggregateMaxSales;
 

--- a/samples/grids/pivot-grid/aggregate-units-sold/src/index.tsx
+++ b/samples/grids/pivot-grid/aggregate-units-sold/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrPivotGridModule } from 'igniteui-react-grids';
 import { IgrPivotGrid, IgrPivotConfiguration, IgrPivotDimension, IgrPivotValue, IgrPivotAggregator } from 'igniteui-react-grids';
 import { PivotSalesDataItem, PivotSalesData } from './PivotSalesData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrPivotGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrPivotGrid
@@ -23,22 +18,22 @@ export default class Sample extends React.Component<any, any> {
     public get pivotConfiguration1(): IgrPivotConfiguration {
         if (this._pivotConfiguration1 == null)
         {
-            var pivotConfiguration1: IgrPivotConfiguration = {} as IgrPivotConfiguration;
+            let pivotConfiguration1: IgrPivotConfiguration = {} as IgrPivotConfiguration;
 
-            var igrPivotDimension1: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension1: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension1.memberName = "Country";
             igrPivotDimension1.enabled = true;
 
             pivotConfiguration1.columns = [igrPivotDimension1];
-            var igrPivotDimension2: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension2: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension2.memberName = "Product";
             igrPivotDimension2.enabled = true;
 
             pivotConfiguration1.rows = [igrPivotDimension2];
-            var igrPivotValue1: IgrPivotValue = {} as IgrPivotValue;
+            let igrPivotValue1: IgrPivotValue = {} as IgrPivotValue;
             igrPivotValue1.member = "Sales";
             igrPivotValue1.enabled = true;
-            var igrPivotAggregator1: IgrPivotAggregator = {} as IgrPivotAggregator;
+            let igrPivotAggregator1: IgrPivotAggregator = {} as IgrPivotAggregator;
             igrPivotAggregator1.key = "MAX";
             igrPivotAggregator1.label = "SalesValue";
             igrPivotAggregator1.aggregator = this.pivotSalesDataAggregateUnitsSold;

--- a/samples/grids/pivot-grid/features/src/index.tsx
+++ b/samples/grids/pivot-grid/features/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrPivotGridModule } from 'igniteui-react-grids';
 import { IgrPivotGrid, IgrPivotConfiguration, IgrPivotDateDimension, IgrPivotDimension, IgrPivotDateDimensionOptions, SortingDirection, IgrPivotValue, IgrPivotAggregator } from 'igniteui-react-grids';
 import { PivotDataFlatItem, PivotDataFlat } from './PivotDataFlat';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrPivotGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrPivotGrid
@@ -23,17 +18,17 @@ export default class Sample extends React.Component<any, any> {
     public get pivotConfiguration1(): IgrPivotConfiguration {
         if (this._pivotConfiguration1 == null)
         {
-            var pivotConfiguration1: IgrPivotConfiguration = {} as IgrPivotConfiguration;
+            let pivotConfiguration1: IgrPivotConfiguration = {} as IgrPivotConfiguration;
 
-            var igrPivotDateDimension1 = new IgrPivotDateDimension();
+            let igrPivotDateDimension1 = new IgrPivotDateDimension();
             igrPivotDateDimension1.memberName = "Date";
             igrPivotDateDimension1.enabled = true;
-            var igrPivotDimension1: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension1: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension1.memberName = "Date";
             igrPivotDimension1.enabled = true;
 
             igrPivotDateDimension1.baseDimension = igrPivotDimension1;
-            var igrPivotDateDimensionOptions1: IgrPivotDateDimensionOptions = {} as IgrPivotDateDimensionOptions;
+            let igrPivotDateDimensionOptions1: IgrPivotDateDimensionOptions = {} as IgrPivotDateDimensionOptions;
             igrPivotDateDimensionOptions1.years = true;
             igrPivotDateDimensionOptions1.months = false;
             igrPivotDateDimensionOptions1.quarters = true;
@@ -42,42 +37,42 @@ export default class Sample extends React.Component<any, any> {
             igrPivotDateDimension1.options = igrPivotDateDimensionOptions1;
 
             pivotConfiguration1.columns = [igrPivotDateDimension1];
-            var igrPivotDimension2: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension2: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension2.memberName = "ProductName";
             igrPivotDimension2.sortDirection = SortingDirection.Asc;
             igrPivotDimension2.enabled = true;
 
-            var igrPivotDimension3: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension3: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension3.memberName = "SellerCity";
             igrPivotDimension3.enabled = true;
 
             pivotConfiguration1.rows = [igrPivotDimension2,igrPivotDimension3];
-            var igrPivotDimension4: IgrPivotDimension = {} as IgrPivotDimension;
+            let igrPivotDimension4: IgrPivotDimension = {} as IgrPivotDimension;
             igrPivotDimension4.memberName = "SellerName";
             igrPivotDimension4.enabled = true;
 
             pivotConfiguration1.filters = [igrPivotDimension4];
-            var igrPivotValue1: IgrPivotValue = {} as IgrPivotValue;
+            let igrPivotValue1: IgrPivotValue = {} as IgrPivotValue;
             igrPivotValue1.member = "AmountofSale";
             igrPivotValue1.displayName = "Amount of Sale";
             igrPivotValue1.enabled = true;
-            var igrPivotAggregator1: IgrPivotAggregator = {} as IgrPivotAggregator;
+            let igrPivotAggregator1: IgrPivotAggregator = {} as IgrPivotAggregator;
             igrPivotAggregator1.key = "SUM";
             igrPivotAggregator1.label = "Sum of Sale";
             igrPivotAggregator1.aggregator = this.pivotDataFlatAggregateSumSale;
 
             igrPivotValue1.aggregate = igrPivotAggregator1;
-            var igrPivotAggregator2: IgrPivotAggregator = {} as IgrPivotAggregator;
+            let igrPivotAggregator2: IgrPivotAggregator = {} as IgrPivotAggregator;
             igrPivotAggregator2.key = "SUM";
             igrPivotAggregator2.label = "Sum of Sale";
             igrPivotAggregator2.aggregator = this.pivotDataFlatAggregateSumSale;
 
-            var igrPivotAggregator3: IgrPivotAggregator = {} as IgrPivotAggregator;
+            let igrPivotAggregator3: IgrPivotAggregator = {} as IgrPivotAggregator;
             igrPivotAggregator3.key = "MIN";
             igrPivotAggregator3.label = "Minimum of Sale";
             igrPivotAggregator3.aggregator = this.pivotDataFlatAggregateMinSale;
 
-            var igrPivotAggregator4: IgrPivotAggregator = {} as IgrPivotAggregator;
+            let igrPivotAggregator4: IgrPivotAggregator = {} as IgrPivotAggregator;
             igrPivotAggregator4.key = "MAX";
             igrPivotAggregator4.label = "Maximum of Sale";
             igrPivotAggregator4.aggregator = this.pivotDataFlatAggregateMaxSale;

--- a/samples/grids/tree-grid/action-strip/src/index.tsx
+++ b/samples/grids/tree-grid/action-strip/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrActionStrip, IgrGridPinningActions, IgrGridEditingActions, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/advanced-filtering-options/src/index.tsx
+++ b/samples/grids/tree-grid/advanced-filtering-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -94,7 +89,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/advanced-filtering-style/src/index.tsx
+++ b/samples/grids/tree-grid/advanced-filtering-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -94,7 +89,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/cell-editing-sample/src/index.tsx
+++ b/samples/grids/tree-grid/cell-editing-sample/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrSelectModule } from 'igniteui-react';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule, WebSelectDescriptionModule } from 'igniteui-react-core';
@@ -13,7 +12,6 @@ import { IgrSelect, IgrSelectItem } from 'igniteui-react';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrTreeGridModule,
     IgrSelectModule
 ];
 mods.forEach((m) => m.register());
@@ -94,7 +92,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
             WebSelectDescriptionModule.register(context);
         }
@@ -106,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
         let uniqueValues: any = [];
         const cell = e.dataContext.cell;
         const colIndex = cell.id.columnID;
-        var treeGrid1 = this.treeGrid1;
+        let treeGrid1 = this.treeGrid1;
         const field: string = treeGrid1.getColumnByVisibleIndex(colIndex).field;
         let roleplayTreeGridData = treeGrid1.data;
         const key = field + "_" + cell.id.rowID;

--- a/samples/grids/tree-grid/cell-editing-styling/src/index.tsx
+++ b/samples/grids/tree-grid/cell-editing-styling/src/index.tsx
@@ -2,18 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrPaginatorModule, IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebPaginatorDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrPaginatorModule,
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -89,7 +84,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebPaginatorDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/cell-merge-custom-sample/src/EmployeesFlatDetails2.ts
+++ b/samples/grids/tree-grid/cell-merge-custom-sample/src/EmployeesFlatDetails2.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+ 
 export const generateEmployeeDetailedFlatData2 = () => ([
     {
         Address: 'Obere Str. 57',

--- a/samples/grids/tree-grid/cell-selection-mode/src/index.tsx
+++ b/samples/grids/tree-grid/cell-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -110,7 +108,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/cell-selection-style/src/index.tsx
+++ b/samples/grids/tree-grid/cell-selection-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -87,7 +82,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/clipboard-operations/src/index.tsx
+++ b/samples/grids/tree-grid/clipboard-operations/src/index.tsx
@@ -2,17 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrColumnComponentEventArgs, IgrTreeGridModule } from 'igniteui-react-grids';
+import { IgrColumnComponentEventArgs } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import { IgrInput, IgrSwitch, IgrButton } from 'igniteui-react';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private defaultSeparator = " ";

--- a/samples/grids/tree-grid/column-auto-sizing/src/index.tsx
+++ b/samples/grids/tree-grid/column-auto-sizing/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -124,7 +119,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-collapsible-groups/src/index.tsx
+++ b/samples/grids/tree-grid/column-collapsible-groups/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumnGroup, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -169,7 +164,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-data-types/src/index.tsx
+++ b/samples/grids/tree-grid/column-data-types/src/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 
-import { IgrTreeGridModule } from "igniteui-react-grids";
 import {
   IgrTreeGrid,
   IgrColumn,
@@ -12,7 +11,6 @@ import {
 import "igniteui-react-grids/grids/themes/light/bootstrap.css";
 import { EMPLOYEES_DATA } from "./EmployeesData";
 
-IgrTreeGridModule.register();
 
 export default function Sample() {
   const columnPipeArgs1: IgrColumnPipeArgs = {

--- a/samples/grids/tree-grid/column-hiding-toolbar-style/src/index.tsx
+++ b/samples/grids/tree-grid/column-hiding-toolbar-style/src/index.tsx
@@ -2,18 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridToolbarModule, IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridToolbarDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
+
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridToolbarModule,
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -131,7 +127,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridToolbarDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/column-hiding-toolbar/src/index.tsx
+++ b/samples/grids/tree-grid/column-hiding-toolbar/src/index.tsx
@@ -2,18 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridToolbarModule, IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridToolbarDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridToolbarModule,
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -125,7 +120,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridToolbarDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/column-moving-options/src/index.tsx
+++ b/samples/grids/tree-grid/column-moving-options/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
@@ -10,10 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -120,7 +115,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -137,8 +132,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var treeGrid = this.treeGrid;
-        var col = treeGrid.getColumnByName(field);
+        let treeGrid = this.treeGrid;
+        let col = treeGrid.getColumnByName(field);
         col.pinned = !col.pinned;
         treeGrid.markForCheck();
     }

--- a/samples/grids/tree-grid/column-moving-styles/src/index.tsx
+++ b/samples/grids/tree-grid/column-moving-styles/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
@@ -10,10 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -120,7 +115,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -137,8 +132,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var treeGrid = this.grid;
-        var col = treeGrid.getColumnByName(field);
+        let treeGrid = this.grid;
+        let col = treeGrid.getColumnByName(field);
         col.pinned = !col.pinned;
         treeGrid.markForCheck();
     }

--- a/samples/grids/tree-grid/column-pinning-options/src/index.tsx
+++ b/samples/grids/tree-grid/column-pinning-options/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
@@ -10,10 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -91,7 +86,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -108,8 +103,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var treeGrid = this.treeGrid;
-        var col = treeGrid.getColumnByName(field);
+        let treeGrid = this.treeGrid;
+        let col = treeGrid.getColumnByName(field);
         col.pinned = !col.pinned;
         treeGrid.markForCheck();
     }

--- a/samples/grids/tree-grid/column-pinning-right-side/src/index.tsx
+++ b/samples/grids/tree-grid/column-pinning-right-side/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPinningConfig, ColumnPinningPosition, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -24,7 +19,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.columns = ColumnPinningPosition.End;
 
             this._pinningConfig1 = pinningConfig1;
@@ -132,7 +127,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-pinning-styles/src/index.tsx
+++ b/samples/grids/tree-grid/column-pinning-styles/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
@@ -10,10 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -91,7 +86,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -108,8 +103,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleColumnPin(field: string) {
-        var treeGrid = this.treeGrid;
-        var col = treeGrid.getColumnByName(field);
+        let treeGrid = this.treeGrid;
+        let col = treeGrid.getColumnByName(field);
         col.pinned = !col.pinned;
         treeGrid.markForCheck();
     }

--- a/samples/grids/tree-grid/column-pinning-toolbar/src/index.tsx
+++ b/samples/grids/tree-grid/column-pinning-toolbar/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -120,7 +115,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-pinning/src/index.tsx
+++ b/samples/grids/tree-grid/column-pinning/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -93,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-resize-styling/src/index.tsx
+++ b/samples/grids/tree-grid/column-resize-styling/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -113,7 +108,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-resizing/src/index.tsx
+++ b/samples/grids/tree-grid/column-resizing/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -113,7 +108,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/column-selection-group/src/index.tsx
+++ b/samples/grids/tree-grid/column-selection-group/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/column-selection-mode/src/index.tsx
+++ b/samples/grids/tree-grid/column-selection-mode/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -13,8 +12,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -105,7 +103,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/column-selection-style/src/index.tsx
+++ b/samples/grids/tree-grid/column-selection-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/column-selection-styles/src/index.tsx
+++ b/samples/grids/tree-grid/column-selection-styles/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/column-sorting-indicators/src/index.tsx
+++ b/samples/grids/tree-grid/column-sorting-indicators/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -24,43 +19,43 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.fieldName = "ID";
             sortingExpression2.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression2)
-            var sortingExpression3: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression3: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression3.dir = SortingDirection.Desc;
             sortingExpression3.fieldName = "Name";
             sortingExpression3.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression3)
-            var sortingExpression4: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression4: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression4.dir = SortingDirection.Asc;
             sortingExpression4.fieldName = "Category";
             sortingExpression4.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression4)
-            var sortingExpression5: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression5: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression5.dir = SortingDirection.Asc;
             sortingExpression5.fieldName = "OrderDate";
             sortingExpression5.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression5)
-            var sortingExpression6: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression6: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression6.dir = SortingDirection.Asc;
             sortingExpression6.fieldName = "Price";
             sortingExpression6.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression6)
-            var sortingExpression7: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression7: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression7.dir = SortingDirection.Asc;
             sortingExpression7.fieldName = "Units";
             sortingExpression7.ignoreCase = true;
 
             sortingExpression1.push(sortingExpression7)
-            var sortingExpression8: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression8: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression8.dir = SortingDirection.Asc;
             sortingExpression8.fieldName = "Delivered";
             sortingExpression8.ignoreCase = true;
@@ -74,7 +69,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 

--- a/samples/grids/tree-grid/column-sorting-options/src/index.tsx
+++ b/samples/grids/tree-grid/column-sorting-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrSortingExpression, SortingDirection, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -38,7 +36,7 @@ export default class Sample extends React.Component<any, any> {
         if (this._sortingExpression1 == null)
         {
             let sortingExpression1: IgrSortingExpression[] = [];
-            var sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
+            let sortingExpression2: IgrSortingExpression = {} as IgrSortingExpression;
             sortingExpression2.fieldName = "Category";
             sortingExpression2.dir = SortingDirection.Asc;
             sortingExpression2.ignoreCase = true;
@@ -52,7 +50,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -161,7 +159,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }
@@ -169,7 +167,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridClearSort(sender: any, args: IgrPropertyEditorPropertyDescriptionButtonClickEventArgs): void {
-        var grid = this.grid;
+        let grid = this.grid;
         grid.clearSort("");
     }
 

--- a/samples/grids/tree-grid/column-sorting-style/src/index.tsx
+++ b/samples/grids/tree-grid/column-sorting-style/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn, IgrColumnPipeArgs } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
@@ -11,8 +10,7 @@ import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -26,7 +24,7 @@ export default class Sample extends React.Component<any, any> {
     public get columnPipeArgs1(): IgrColumnPipeArgs {
         if (this._columnPipeArgs1 == null)
         {
-            var columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
+            let columnPipeArgs1: IgrColumnPipeArgs = {} as IgrColumnPipeArgs;
             columnPipeArgs1.currencyCode = "USD";
             columnPipeArgs1.digitsInfo = "1.2-2";
 
@@ -118,7 +116,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/conditional-cell-style-1/src/index.tsx
+++ b/samples/grids/tree-grid/conditional-cell-style-1/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/conditional-cell-style-2/src/index.tsx
+++ b/samples/grids/tree-grid/conditional-cell-style-2/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/conditional-row-selectors/src/index.tsx
+++ b/samples/grids/tree-grid/conditional-row-selectors/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
@@ -10,10 +9,6 @@ import { IgrRowSelectionEventArgs, IgrGrid } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -82,7 +77,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -94,7 +89,7 @@ export default class Sample extends React.Component<any, any> {
             // ignore de-select
             return;
         }
-        var grid = this.treeGrid;
+        let grid = this.treeGrid;
         const originalAddedLength = event.added.length;
 
         // only allow selection for employees that are not pn PTO

--- a/samples/grids/tree-grid/data-summary-children/src/index.tsx
+++ b/samples/grids/tree-grid/data-summary-children/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -131,7 +129,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }
@@ -139,12 +137,12 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webTreeGridChangeSummaryCalculationMode(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-      var treeGrid = this.treeGrid;
+      let treeGrid = this.treeGrid;
       treeGrid.summaryCalculationMode = args.newValue;
     }
 
     public webTreeGridChangeSummaryPosition(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-      var treeGrid = this.treeGrid;
+      let treeGrid = this.treeGrid;
       treeGrid.summaryPosition = args.newValue;
     }
 

--- a/samples/grids/tree-grid/data-summary-formatter/src/index.tsx
+++ b/samples/grids/tree-grid/data-summary-formatter/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
@@ -10,10 +9,6 @@ import { IgrSummaryResult, IgrSummaryOperand } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -109,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/data-summary-options-styling/src/index.tsx
+++ b/samples/grids/tree-grid/data-summary-options-styling/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
@@ -10,10 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -113,7 +108,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/data-summary-options/src/index.tsx
+++ b/samples/grids/tree-grid/data-summary-options/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
@@ -10,10 +9,6 @@ import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -107,7 +102,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/data-summary-template/src/index.tsx
+++ b/samples/grids/tree-grid/data-summary-template/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -129,7 +127,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }
@@ -139,9 +137,9 @@ export default class Sample extends React.Component<any, any> {
     public webTreeGridHasSummariesChange(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
         let newValue = sender.primitiveValue as boolean;
         const grid = this.treeGrid;
-        var column1 = grid.getColumnByName("Age");
-        var column2 = grid.getColumnByName("Title");
-        var column3 = grid.getColumnByName("OnPTO");
+        let column1 = grid.getColumnByName("Age");
+        let column2 = grid.getColumnByName("Title");
+        let column3 = grid.getColumnByName("OnPTO");
 
         column1.hasSummary = newValue;
         column2.hasSummary = newValue;
@@ -149,8 +147,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webTreeGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("treeGrid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("treeGrid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/tree-grid/editing-columns/src/index.tsx
+++ b/samples/grids/tree-grid/editing-columns/src/index.tsx
@@ -2,18 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrPaginatorModule, IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebPaginatorDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrPaginatorModule,
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
+
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -94,7 +89,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebPaginatorDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/editing-events/src/index.tsx
+++ b/samples/grids/tree-grid/editing-events/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
@@ -10,10 +9,6 @@ import { IgrGrid, IgrGridEditEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -79,7 +74,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/editing-lifecycle/src/index.tsx
+++ b/samples/grids/tree-grid/editing-lifecycle/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
-import { IgrGridEditEventArgs, IgrGrid, IgrGridEditDoneEventArgs } from 'igniteui-react-grids';
+import { IgrGridEditEventArgs, IgrGridEditDoneEventArgs } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -109,7 +104,7 @@ export default class Sample extends React.Component<any, any> {
     public webGridRowEditEnter(args: IgrGridEditEventArgs): void {
         let container = document.getElementById("container");
         const message = document.createElement("p");
-        message.textContent = `=> 'rowEditEnter' with 'RowID':` + args.detail.rowID;
+        message.textContent = `=> 'rowEditEnter' with 'RowID':` + args.detail.rowKey;
         container.appendChild(message);
     }
 

--- a/samples/grids/tree-grid/excel-exporting/src/index.tsx
+++ b/samples/grids/tree-grid/excel-exporting/src/index.tsx
@@ -2,17 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrGridToolbarModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesNestedDataItem, EmployeesNestedDataItem_EmployeesItem, EmployeesNestedData } from './EmployeesNestedData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrGridToolbarModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/excel-style-filtering-sample-1/src/index.tsx
+++ b/samples/grids/tree-grid/excel-style-filtering-sample-1/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebGridDescriptionModule } from 'igniteui-react-core';
@@ -15,8 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -132,7 +130,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebGridDescriptionModule.register(context);
         }
@@ -140,8 +138,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webTreeGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("treeGrid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("treeGrid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/tree-grid/excel-style-filtering-sample-2/src/index.tsx
+++ b/samples/grids/tree-grid/excel-style-filtering-sample-2/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { FoodsDataItem, FoodsData } from './FoodsData';
@@ -10,10 +9,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -102,7 +97,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/excel-style-filtering-sample-3/src/index.tsx
+++ b/samples/grids/tree-grid/excel-style-filtering-sample-3/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarHiding, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { FoodsDataItem, FoodsData } from './FoodsData';
@@ -10,10 +9,6 @@ import { IgrGridHeaderTemplateContext, IgrCellTemplateContext } from 'igniteui-r
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -98,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/excel-style-filtering-style/src/index.tsx
+++ b/samples/grids/tree-grid/excel-style-filtering-style/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { FoodsDataItem, FoodsData } from './FoodsData';
@@ -10,10 +9,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -89,7 +84,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/filtering-options/src/index.tsx
+++ b/samples/grids/tree-grid/filtering-options/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { OrdersDataItem, OrdersData } from './OrdersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/filtering-style/src/index.tsx
+++ b/samples/grids/tree-grid/filtering-style/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { OrdersDataItem, OrdersData } from './OrdersData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/keyboard-custom-navigation/src/index.tsx
+++ b/samples/grids/tree-grid/keyboard-custom-navigation/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedDataItem, EmployeesNestedDataItem_EmployeesItem, EmployeesNestedData } from './EmployeesNestedData';
@@ -12,8 +11,7 @@ import { IgrGrid, IgrGridKeydownEventArgs } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -92,7 +90,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/layout-display-density/src/index.tsx
+++ b/samples/grids/tree-grid/layout-display-density/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -172,7 +170,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }
@@ -180,8 +178,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webTreeGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("treeGrid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("treeGrid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/tree-grid/multi-cell-selection-mode/src/index.tsx
+++ b/samples/grids/tree-grid/multi-cell-selection-mode/src/index.tsx
@@ -5,20 +5,12 @@ import "./index.css";
 import {
   IgrColumn,
   IgrGrid,
-  IgrGridModule,
   IgrGridSelectionRangeEventArgs,
   IgrTreeGrid,
-  IgrTreeGridModule,
 } from "igniteui-react-grids";
 import { EmployeesFlatData } from "./EmployeesFlatData";
 
 import "igniteui-react-grids/grids/themes/light/bootstrap.css";
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default function App() {
   const employeesFlatData = new EmployeesFlatData();

--- a/samples/grids/tree-grid/multi-column-headers-export/src/index.tsx
+++ b/samples/grids/tree-grid/multi-column-headers-export/src/index.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrGridToolbarModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarPinning, IgrGridToolbarHiding, IgrGridToolbarExporter, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebGridToolbarDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 import { IgrExporterEventArgs, IgrGrid } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrGridToolbarModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -159,7 +152,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebGridToolbarDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/multi-column-headers-overview/src/index.tsx
+++ b/samples/grids/tree-grid/multi-column-headers-overview/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
@@ -14,8 +13,6 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrGridModule,
-    IgrColumnGroupModule,
     IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
@@ -165,7 +162,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
             PropertyEditorPanelDescriptionModule.register(context);

--- a/samples/grids/tree-grid/multi-column-headers-styling/src/index.tsx
+++ b/samples/grids/tree-grid/multi-column-headers-styling/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -127,7 +122,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/multi-column-headers-template/src/index.tsx
+++ b/samples/grids/tree-grid/multi-column-headers-template/src/index.tsx
@@ -2,19 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrGridModule, IgrColumnGroupModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn, IgrColumnGroup } from 'igniteui-react-grids';
 import { ComponentRenderer, WebGridDescriptionModule, WebColumnGroupDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
 import { IgrColumnTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrGridModule,
-    IgrColumnGroupModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -144,7 +137,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebGridDescriptionModule.register(context);
             WebColumnGroupDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/overview-styling/src/index.tsx
+++ b/samples/grids/tree-grid/overview-styling/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedDataItem, EmployeesNestedDataItem_EmployeesItem, EmployeesNestedData } from './EmployeesNestedData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -82,7 +77,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/overview/src/index.tsx
+++ b/samples/grids/tree-grid/overview/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule, IgrPaginatorModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrGridToolbar, IgrGridToolbarTitle, IgrGridToolbarActions, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule, WebPaginatorDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedDataItem, EmployeesNestedDataItem_EmployeesItem, EmployeesNestedData } from './EmployeesNestedData';
@@ -11,9 +10,7 @@ import { EmployeesNestedDataItem, EmployeesNestedDataItem_EmployeesItem, Employe
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule,
-    IgrPaginatorModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -112,7 +109,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
             WebPaginatorDescriptionModule.register(context);

--- a/samples/grids/tree-grid/row-adding/src/index.tsx
+++ b/samples/grids/tree-grid/row-adding/src/index.tsx
@@ -2,18 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule, IgrActionStripModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrActionStrip, IgrGridEditingActions, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule, WebActionStripDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrTreeGridModule,
-    IgrActionStripModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -101,7 +94,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
             WebActionStripDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/row-classes/src/index.tsx
+++ b/samples/grids/tree-grid/row-classes/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
 import { IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/row-editing-options/src/index.tsx
+++ b/samples/grids/tree-grid/row-editing-options/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -95,7 +90,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/row-editing-style/src/index.tsx
+++ b/samples/grids/tree-grid/row-editing-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private grid: IgrTreeGrid
@@ -95,7 +90,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/row-paging-basic/src/index.tsx
+++ b/samples/grids/tree-grid/row-paging-basic/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -98,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/row-paging-options/src/index.tsx
+++ b/samples/grids/tree-grid/row-paging-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrPaginator, IgrPaginatorResourceStrings, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule } from 'igniteui-react-core';
@@ -14,8 +13,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -36,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get paginatorResourceStrings1(): IgrPaginatorResourceStrings {
         if (this._paginatorResourceStrings1 == null)
         {
-            var paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
+            let paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
             paginatorResourceStrings1.igx_paginator_label = "Records per page";
 
             this._paginatorResourceStrings1 = paginatorResourceStrings1;
@@ -142,7 +140,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
         }
@@ -150,8 +148,8 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webTreeGridSetGridSize(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newVal = (args.newValue as string).toLowerCase();
-        var grid = document.getElementById("treeGrid");
+        let newVal = (args.newValue as string).toLowerCase();
+        let grid = document.getElementById("treeGrid");
         grid.style.setProperty('--ig-size', `var(--ig-size-${newVal})`);
     }
 

--- a/samples/grids/tree-grid/row-paging-style/src/index.tsx
+++ b/samples/grids/tree-grid/row-paging-style/src/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { OrdersTreeDataItem, OrdersTreeData } from './OrdersTreeData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -98,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/row-pinning-extra-column/src/index.tsx
+++ b/samples/grids/tree-grid/row-pinning-extra-column/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPinningConfig, RowPinningPosition, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
@@ -10,10 +9,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -25,7 +20,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -93,7 +88,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;
@@ -107,7 +102,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public toggleRowPin(index: number) {
-        var treeGrid = this.treeGrid;
+        let treeGrid = this.treeGrid;
         treeGrid.getRowByIndex(index).pinned = !treeGrid.getRowByIndex(index).pinned;
     }
 }

--- a/samples/grids/tree-grid/row-pinning-options/src/index.tsx
+++ b/samples/grids/tree-grid/row-pinning-options/src/index.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
-import { IgrTreeGridModule, IgrActionStripModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrPinningConfig, RowPinningPosition, IgrColumn, IgrActionStrip, IgrGridPinningActions } from 'igniteui-react-grids';
 import { ComponentRenderer, PropertyEditorPanelDescriptionModule, WebTreeGridDescriptionModule, WebActionStripDescriptionModule } from 'igniteui-react-core';
@@ -15,9 +14,7 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrPropertyEditorPanelModule,
-    IgrTreeGridModule,
-    IgrActionStripModule
+    IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
 
@@ -37,7 +34,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -129,7 +126,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             PropertyEditorPanelDescriptionModule.register(context);
             WebTreeGridDescriptionModule.register(context);
             WebActionStripDescriptionModule.register(context);
@@ -138,14 +135,14 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webGridSetRowPinning(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var item = sender as IgrPropertyEditorPropertyDescription;
-        var newVal = item.primitiveValue;
-        var grid = this.treeGrid;
+        let item = sender as IgrPropertyEditorPropertyDescription;
+        let newVal = item.primitiveValue;
+        let grid = this.treeGrid;
         grid.pinning.rows = newVal === "Top" ? RowPinningPosition.Top : RowPinningPosition.Bottom;
     }
 
     public webTreeGridPinRowOnRendered(args:any): void {
-        var treeGrid = this.treeGrid;
+        let treeGrid = this.treeGrid;
         treeGrid.pinRow(1);
         treeGrid.pinRow(11);
     }

--- a/samples/grids/tree-grid/row-pinning-style/src/index.tsx
+++ b/samples/grids/tree-grid/row-pinning-style/src/index.tsx
@@ -2,19 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule, IgrActionStripModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPinningConfig, RowPinningPosition, IgrColumn, IgrActionStrip, IgrGridPinningActions } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule, WebActionStripDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
-import { IgrGrid } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
-
-const mods: any[] = [
-    IgrTreeGridModule,
-    IgrActionStripModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -26,7 +18,7 @@ export default class Sample extends React.Component<any, any> {
     public get pinningConfig1(): IgrPinningConfig {
         if (this._pinningConfig1 == null)
         {
-            var pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
+            let pinningConfig1: IgrPinningConfig = {} as IgrPinningConfig;
             pinningConfig1.rows = RowPinningPosition.Top;
 
             this._pinningConfig1 = pinningConfig1;
@@ -98,7 +90,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
             WebActionStripDescriptionModule.register(context);
         }
@@ -106,7 +98,7 @@ export default class Sample extends React.Component<any, any> {
     }
 
     public webTreeGridPinRowOnRendered(args:any): void {
-        var treeGrid = this.treeGrid;
+        let treeGrid = this.treeGrid;
         treeGrid.pinRow(1);
         treeGrid.pinRow(11);
     }

--- a/samples/grids/tree-grid/row-reorder/src/index.tsx
+++ b/samples/grids/tree-grid/row-reorder/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesNestedTreeDataItem, EmployeesNestedTreeData } from './EmployeesNestedTreeData';
@@ -10,10 +9,6 @@ import { IgrRowDragStartEventArgs, IgrRowDragEndEventArgs } from 'igniteui-react
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -98,7 +93,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/row-selection-mode/src/index.tsx
+++ b/samples/grids/tree-grid/row-selection-mode/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrPropertyEditorPanelModule } from 'igniteui-react-layouts';
 import { IgrPropertyEditorPanel, IgrPropertyEditorPropertyDescription } from 'igniteui-react-layouts';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
@@ -13,7 +12,6 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrTreeGridModule,
     IgrPropertyEditorPanelModule
 ];
 mods.forEach((m) => m.register());
@@ -127,7 +125,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
             PropertyEditorPanelDescriptionModule.register(context);
         }

--- a/samples/grids/tree-grid/row-selection-template-excel/src/index.tsx
+++ b/samples/grids/tree-grid/row-selection-template-excel/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrPaginator, IgrPaginatorResourceStrings, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
@@ -10,10 +9,6 @@ import { IgrRowSelectorTemplateContext, IgrHeadSelectorTemplateContext } from 'i
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -26,7 +21,7 @@ export default class Sample extends React.Component<any, any> {
     public get paginatorResourceStrings1(): IgrPaginatorResourceStrings {
         if (this._paginatorResourceStrings1 == null)
         {
-            var paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
+            let paginatorResourceStrings1: IgrPaginatorResourceStrings = {} as IgrPaginatorResourceStrings;
             paginatorResourceStrings1.igx_paginator_label = "Items per page";
 
             this._paginatorResourceStrings1 = paginatorResourceStrings1;
@@ -110,7 +105,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/row-selection-template-numbers/src/index.tsx
+++ b/samples/grids/tree-grid/row-selection-template-numbers/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
 import { IgrRowSelectorTemplateContext, IgrHeadSelectorTemplateContext } from 'igniteui-react-grids';
@@ -10,10 +9,6 @@ import { IgrCheckbox } from 'igniteui-react';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/grids/tree-grid/row-styles/src/index.tsx
+++ b/samples/grids/tree-grid/row-styles/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { ComponentRenderer, WebTreeGridDescriptionModule } from 'igniteui-react-core';
 import { EmployeesFlatDetailsItem, EmployeesFlatDetails } from './EmployeesFlatDetails';
@@ -11,10 +10,6 @@ import { IgrRowType } from 'igniteui-react-grids';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid
@@ -90,7 +85,7 @@ export default class Sample extends React.Component<any, any> {
     public get renderer(): ComponentRenderer {
         if (this._componentRenderer == null) {
             this._componentRenderer = new ComponentRenderer();
-            var context = this._componentRenderer.context;
+            let context = this._componentRenderer.context;
             WebTreeGridDescriptionModule.register(context);
         }
         return this._componentRenderer;

--- a/samples/grids/tree-grid/toolbar-sample-1/src/index.tsx
+++ b/samples/grids/tree-grid/toolbar-sample-1/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrAvatarModule } from 'igniteui-react';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatAvatarsItem, EmployeesFlatAvatars } from './EmployeesFlatAvatars';
@@ -12,7 +11,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrTreeGridModule,
     IgrAvatarModule
 ];
 mods.forEach((m) => m.register());

--- a/samples/grids/tree-grid/toolbar-sample-2/src/index.tsx
+++ b/samples/grids/tree-grid/toolbar-sample-2/src/index.tsx
@@ -12,7 +12,6 @@ import {
   IgrGridToolbarPinning,
   IgrGridToolbarTitle,
   IgrTreeGrid,
-  IgrTreeGridModule,
 } from "igniteui-react-grids";
 import { IgrColumn } from "igniteui-react-grids";
 import { IgrAvatar, IgrAvatarModule, IgrCheckboxChangeEventArgs, IgrComponentValueChangedEventArgs, IgrInput, IgrInputModule, IgrSwitch, IgrSwitchModule } from "igniteui-react";
@@ -21,7 +20,6 @@ import "igniteui-react-grids/grids/themes/light/bootstrap.css";
 
 import { EmployeesFlatAvatars } from "./EmployeesFlatAvatars";
 
-IgrTreeGridModule.register();
 IgrAvatarModule.register();
 IgrSwitchModule.register();
 IgrInputModule.register();

--- a/samples/grids/tree-grid/toolbar-sample-3/src/index.tsx
+++ b/samples/grids/tree-grid/toolbar-sample-3/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrAvatarModule } from 'igniteui-react';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatAvatarsItem, EmployeesFlatAvatars } from './EmployeesFlatAvatars';
@@ -13,7 +12,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrTreeGridModule,
     IgrAvatarModule
 ];
 mods.forEach((m) => m.register());

--- a/samples/grids/tree-grid/toolbar-sample-4/src/index.tsx
+++ b/samples/grids/tree-grid/toolbar-sample-4/src/index.tsx
@@ -11,7 +11,6 @@ import {
   IgrGridToolbarPinning,
   IgrGridToolbarTitle,
   IgrTreeGrid,
-  IgrTreeGridModule,
 } from "igniteui-react-grids";
 import { IgrColumn } from "igniteui-react-grids";
 import { IgrAvatar, IgrAvatarModule, IgrButton, IgrIcon, IgrIconModule, registerIconFromText } from "igniteui-react";
@@ -20,7 +19,6 @@ import "igniteui-react-grids/grids/themes/light/bootstrap.css";
 
 import { EmployeesFlatAvatars } from "./EmployeesFlatAvatars";
 
-IgrTreeGridModule.register();
 IgrAvatarModule.register();
 IgrIconModule.register();
 

--- a/samples/grids/tree-grid/toolbar-style/src/index.tsx
+++ b/samples/grids/tree-grid/toolbar-style/src/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrAvatarModule } from 'igniteui-react';
 import { IgrTreeGrid, IgrGridToolbar, IgrGridToolbarActions, IgrGridToolbarAdvancedFiltering, IgrGridToolbarHiding, IgrGridToolbarPinning, IgrGridToolbarExporter, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatAvatarsItem, EmployeesFlatAvatars } from './EmployeesFlatAvatars';
@@ -12,7 +11,6 @@ import { IgrCellTemplateContext } from 'igniteui-react-grids';
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
 const mods: any[] = [
-    IgrTreeGridModule,
     IgrAvatarModule
 ];
 mods.forEach((m) => m.register());

--- a/samples/grids/tree-grid/using-primary-foreign-keys/src/index.tsx
+++ b/samples/grids/tree-grid/using-primary-foreign-keys/src/index.tsx
@@ -2,16 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { IgrTreeGridModule } from 'igniteui-react-grids';
 import { IgrTreeGrid, IgrColumn } from 'igniteui-react-grids';
 import { EmployeesFlatDataItem, EmployeesFlatData } from './EmployeesFlatData';
 
 import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 
-const mods: any[] = [
-    IgrTreeGridModule
-];
-mods.forEach((m) => m.register());
 
 export default class Sample extends React.Component<any, any> {
     private treeGrid: IgrTreeGrid

--- a/samples/inputs/textarea/form-integration/src/index.tsx
+++ b/samples/inputs/textarea/form-integration/src/index.tsx
@@ -14,7 +14,7 @@ export default function TextAreaFormIntegration() {
     toastRef = toast;
   };
 
-  const onSubmitButtonClicked = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmitButtonClicked = (e: React.SubmitEvent<HTMLFormElement>) => {
     if (toastRef) {
       e.preventDefault();
       toastRef.show();

--- a/samples/interactions/query-builder/template/src/index.tsx
+++ b/samples/interactions/query-builder/template/src/index.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 
-import { 
+import {
   IgrQueryBuilder,
-  IgrQueryBuilderModule,
   IgrQueryBuilderHeader,
   IgrFilteringExpressionsTree,
   IgrExpressionTree,
@@ -33,7 +32,6 @@ import 'igniteui-react-grids/grids/themes/light/material.css';
 
 // Register components
 const mods: any[] = [
-  IgrQueryBuilderModule,
   IgrDatePickerModule,
   IgrDateTimeInputModule,
   IgrSelectModule,
@@ -142,14 +140,14 @@ export default class Sample extends React.Component<any, SampleState> {
 
   componentDidUpdate(prevProps: any, prevState: any) {
     // Update query builder if expression tree changed
-    if (this.queryBuilderRef.current && this.state.expressionTree && 
+    if (this.queryBuilderRef.current && this.state.expressionTree &&
         prevState.expressionTree !== this.state.expressionTree) {
       const queryBuilder = this.queryBuilderRef.current;
       queryBuilder.expressionTree = this.state.expressionTree;
     }
 
     // Render expression tree output
-    if (this.expressionOutputRef.current && this.state.expressionTree && 
+    if (this.expressionOutputRef.current && this.state.expressionTree &&
         prevState.expressionTree !== this.state.expressionTree) {
       this.expressionOutputRef.current.textContent = JSON.stringify(this.state.expressionTree, null, 2);
     }
@@ -226,18 +224,18 @@ export default class Sample extends React.Component<any, SampleState> {
   private normalizeTimeValue = (value: unknown): Date | null => {
     if (!value) return null;
     if (value instanceof Date) return value;
-    
+
     if (typeof value === 'string') {
       const isoCandidate = value.includes('T') ? value : `1970-01-01T${value}`;
       const parsed = new Date(isoCandidate);
       return isNaN(parsed.getTime()) ? null : parsed;
     }
-    
+
     if (typeof value === 'number') {
       const parsed = new Date(value);
       return isNaN(parsed.getTime()) ? null : parsed;
     }
-    
+
     return null;
   };
 
@@ -389,7 +387,7 @@ export default class Sample extends React.Component<any, SampleState> {
     const key = `default-input-${inputValue}`;
 
     return (
-      <IgrInput 
+      <IgrInput
         key={key}
         value={inputValue?.toString() || ''}
         disabled={isDisabled}
@@ -409,13 +407,13 @@ export default class Sample extends React.Component<any, SampleState> {
     return (
       <div className="container sample ig-typography">
         <div className="wrapper">
-          <IgrQueryBuilder 
-            ref={this.queryBuilderRef} 
+          <IgrQueryBuilder
+            ref={this.queryBuilderRef}
             id="queryBuilder"
             searchValueTemplate={this.buildSearchValueTemplate}>
             <IgrQueryBuilderHeader title="Query Builder Template Sample"></IgrQueryBuilderHeader>
           </IgrQueryBuilder>
-          
+
           <div className="output-area">
             <pre ref={this.expressionOutputRef} id="expressionOutput"></pre>
           </div>

--- a/samples/layouts/dock-manager/embedding-frames/src/index.tsx
+++ b/samples/layouts/dock-manager/embedding-frames/src/index.tsx
@@ -30,7 +30,7 @@ export default class DockManagerEmbeddingFrames extends React.Component {
                         src='https://infragistics.com/webcomponents-demos/gauges/radial-gauge-needle' ></iframe>
                     </div>
                     <div className="dockManagerFull" slot="geoMapContainer"  >
-                        <iframe className="dockManagerFrame" seamless frameBorder="0"
+                        <iframe className="dockManagerFrame" seamless frameborder="0"
                         src='https://infragistics.com/react-demos/maps/geo-map-binding-data-csv'  ></iframe>
                     </div>
                 </IgrDockManager>

--- a/samples/maps/geo-map/binding-data-json-shapes/src/index.tsx
+++ b/samples/maps/geo-map/binding-data-json-shapes/src/index.tsx
@@ -65,7 +65,7 @@ export default class MapBindingDataGeoJsonShapes extends React.Component<any, an
         }
 
         let countryName: string = jsonData.features[0].properties.cca2.toUpperCase();
-        let countryDataItem = { label: name, points: shapePoints};
+        let countryDataItem = { label: countryName, points: shapePoints};
 
         // creating geographic series for each country data converted from GeoJSOn data
         // optionally multiple data items for countries could be stored in an array

--- a/samples/scheduling/date-range-picker/form/src/index.tsx
+++ b/samples/scheduling/date-range-picker/form/src/index.tsx
@@ -8,7 +8,7 @@ export default function DrpForm() {
   const dialog = useRef<IgrDialog>(null);
   const [range, setRange] = useState({ start: null, end: null });
 
-  const showDialog = (event: React.FormEvent<HTMLFormElement>) => {
+  const showDialog = (event: React.SubmitEvent<HTMLFormElement>) => {
     if (dialog.current) {
       event.preventDefault();
       dialog.current.show();


### PR DESCRIPTION
Clean up deprecated imports and replace var with let/const 

  - Remove deprecated module imports flagged by @typescript-eslint/no-deprecated
  - Replace `var` declarations with `let`/`const` across sample sources