### PR TITLE
fix: strip @infragistics/ scope from imports in generated code-viewer JSON

### DIFF
--- a/browser/tasks/gulp-samples.js
+++ b/browser/tasks/gulp-samples.js
@@ -277,6 +277,9 @@ function copySamples(cb) {
                 code = code.replace(" var ", " let ");
                 code = code.replace(", MarkerType_$type", "");
                 // auto fix TS lint issue in import statements:
+                // strip @infragistics/ scope from all imports (both 'from' and side-effect 'import')
+                // CI rewrites trial package names to licensed ones in source files before building.
+                code = code.replace(/@infragistics\/(igniteui)/g, '$1');
                 code = code.replace('from "igniteui-react";', "from 'igniteui-react';");
                 code = code.replace('from "igniteui-react-core";', "from 'igniteui-react-core';");
                 code = code.replace('from "igniteui-react-dashboards";', "from 'igniteui-react-dashboards';");
@@ -643,7 +646,8 @@ function updateCodeViewer(cb) {
         // Strip "../samples/{group}/{component}/{name}/" prefix so StackBlitz sdk.openProject() gets
         // project-relative paths like "src/index.tsx" instead of "../samples/.../src/index.tsx".
         var tsxPath = sample.SampleFilePath.replace(sample.SampleFolderPath + '/', '');
-        var tsxItem = new CodeViewer(tsxPath, sample.SampleFileSourceCode, "tsx", "tsx", true);
+        var tsxSourceCode = sample.SampleFileSourceCode.replace(/@infragistics\/(igniteui)/g, '$1');
+        var tsxItem = new CodeViewer(tsxPath, tsxSourceCode, "tsx", "tsx", true);
 
         contentItems.push(tsxItem);
 


### PR DESCRIPTION
The CI/CD pipeline rewrites all `igniteui-react` and `igniteui-dockmanager` import strings in source .tsx/.ts files to their licensed @infragistics/ scoped equivalents before running the build. Since gulp updateBrowser runs as part of the build, getSamples reads the already rewritten source files and updateCodeViewer embeds them into the generated code-viewer JSON files. As a result, end users in the docs site code viewer would see`@infragistics/igniteui-react-*` imports packages that require a license and are not publicly available on npm.