### PR TITLE
fix(*): remove @infragistics/ strip from copySamples

### DIFF
--- a/browser/tasks/gulp-samples.js
+++ b/browser/tasks/gulp-samples.js
@@ -277,9 +277,6 @@ function copySamples(cb) {
                 code = code.replace(" var ", " let ");
                 code = code.replace(", MarkerType_$type", "");
                 // auto fix TS lint issue in import statements:
-                // strip @infragistics/ scope from all imports (both 'from' and side-effect 'import')
-                // CI rewrites trial package names to licensed ones in source files before building.
-                code = code.replace(/@infragistics\/(igniteui)/g, '$1');
                 code = code.replace('from "igniteui-react";', "from 'igniteui-react';");
                 code = code.replace('from "igniteui-react-core";', "from 'igniteui-react-core';");
                 code = code.replace('from "igniteui-react-dashboards";', "from 'igniteui-react-dashboards';");


### PR DESCRIPTION
Previously @infragistics/ stripping in both `copySamples` and `updateCodeViewer strips the scope from imports in the browser samples but at that point only `@infragistics/igniteui-react-*` packages exist in node_modules (trial packages were uninstalled). Vite then fails to resolve the stripped igniteui-react-grids imports, causing the build to break with ENOENT: no such file or directory.

Remove the @infragistics/ strip from `copySamples`. The strip in `updateCodeViewer` is sufficient and only affects the user-facing code-viewer JSONs, never the files Vite compiles.